### PR TITLE
fix: correct Stop hook CLI calls so the mining loop and session provenance work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Memory MCP are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Stop hook mining call** - `hooks/memory-log-response.sh` passed `--session-id` to
+  `run-mining`, which has no such option, so the mining step aborted with a usage error on
+  every hook invocation. The hook now passes only the project filter to `run-mining`;
+  session provenance flows through the logged output instead.
+- **Session provenance in log-response** - The `log-response` Stop hook command parsed the
+  hook input's `session_id` but never stored it, so hook-logged outputs (and the memories
+  mined from them) were never linked to their session. The `session_id` is now passed
+  through to `log_output`, and mined memories inherit it from the source log.
+
 ## [0.7.4] - 2026-01-24
 
 ### Added

--- a/hooks/memory-log-response.sh
+++ b/hooks/memory-log-response.sh
@@ -155,23 +155,27 @@ if [ -n "$LAST_USER_MSG" ] && [ "$LAST_USER_MSG" != "null" ]; then
 ASSISTANT: $LAST_RESPONSE"
 fi
 
-# Build CLI arguments from hook input
-CLI_ARGS=""
+# Build CLI arguments from hook input. run-mining takes no --session-id
+# (mined memories inherit their session from the source log), so it gets
+# the project filter only.
+LOG_ARGS=""
+MINING_ARGS=""
 if [ -n "$PROJECT_PATH" ]; then
-    CLI_ARGS="$CLI_ARGS --project-id=$PROJECT_PATH"
+    LOG_ARGS="$LOG_ARGS --project-id=$PROJECT_PATH"
+    MINING_ARGS="$MINING_ARGS --project-id=$PROJECT_PATH"
 fi
 if [ -n "$SESSION_ID" ]; then
-    CLI_ARGS="$CLI_ARGS --session-id=$SESSION_ID"
+    LOG_ARGS="$LOG_ARGS --session-id=$SESSION_ID"
 fi
 
 # Log the response using memory-mcp-cli
 log_msg "Processing response (${#LAST_RESPONSE} chars) project=${PROJECT_PATH:-none} session=${SESSION_ID:-none}"
 
-if ! echo "$LAST_RESPONSE" | run_cli log-output $CLI_ARGS; then
+if ! echo "$LAST_RESPONSE" | run_cli log-output $LOG_ARGS; then
     log_msg "ERROR: log-output failed with exit code $?"
 fi
 
 # Run mining to extract and store patterns as memories (non-critical)
-run_cli run-mining --hours 1 $CLI_ARGS >> "$HOOK_LOG" 2>&1 || true
+run_cli run-mining --hours 1 $MINING_ARGS >> "$HOOK_LOG" 2>&1 || true
 
 log_msg "Hook completed successfully"

--- a/src/memory_mcp/cli.py
+++ b/src/memory_mcp/cli.py
@@ -113,6 +113,10 @@ def log_response(ctx: click.Context) -> None:
     except json.JSONDecodeError:
         return
 
+    # Session provenance for the logged output; mining inherits the session
+    # from the source log, so losing it here breaks session linking downstream
+    session_id = data.get("session_id") or data.get("sessionId")
+
     # Find transcript path (multiple formats supported)
     transcript_path = (
         data.get("transcript_path")
@@ -122,7 +126,6 @@ def log_response(ctx: click.Context) -> None:
 
     if not transcript_path or not Path(transcript_path).exists():
         # Try to derive from session_id
-        session_id = data.get("session_id") or data.get("sessionId")
         project_path = (
             data.get("project_path")
             or data.get("projectPath")
@@ -200,7 +203,7 @@ def log_response(ctx: click.Context) -> None:
 
     storage = Storage(settings)
     try:
-        storage.log_output(content, project_id=project_id)
+        storage.log_output(content, project_id=project_id, session_id=session_id)
     finally:
         storage.close()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,6 +152,74 @@ class TestRunMiningCommand:
         assert result == 0
 
 
+class TestLogResponseCommand:
+    """Tests for the log-response CLI command (Stop hook entrypoint)."""
+
+    def test_log_response_stores_session_id(self, temp_db, tmp_path):
+        """Outputs logged via the Stop hook carry the hook input's session_id.
+
+        Mining inherits session provenance from the source log
+        (get_recent_outputs returns session_id per log), so log-response
+        must pass the session_id through to storage.log_output.
+        """
+        from memory_mcp.config import get_settings
+        from memory_mcp.storage import Storage
+
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "Which web framework do we use?"}],
+                    }
+                }
+            ),
+            json.dumps(
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "We use FastAPI for the API layer."}],
+                    }
+                }
+            ),
+        ]
+        transcript.write_text("\n".join(lines))
+
+        hook_input = json.dumps(
+            {"transcript_path": str(transcript), "session_id": "sess-hook-test"}
+        )
+
+        # Intercept only the detached mining spawn; the raised error is
+        # swallowed by log-response's try/except, and `tail` keeps working
+        # because subprocess.run delegates to the real Popen.
+        real_popen = subprocess.Popen
+
+        def popen_without_mining_spawn(args, **kwargs):
+            if args and args[0] == "memory-mcp-cli":
+                raise FileNotFoundError("mining spawn suppressed in test")
+            return real_popen(args, **kwargs)
+
+        with (
+            patch("subprocess.Popen", side_effect=popen_without_mining_spawn),
+            patch("sys.stdin.read", return_value=hook_input),
+            patch("sys.argv", ["memory-mcp-cli", "log-response"]),
+        ):
+            result = main()
+        assert result == 0
+
+        settings = get_settings()
+        storage = Storage(settings)
+        try:
+            outputs = storage.get_recent_outputs(hours=1)
+            assert len(outputs) == 1
+            _, content, _, _, session_id = outputs[0]
+            assert "We use FastAPI" in content
+            assert session_id == "sess-hook-test"
+        finally:
+            storage.close()
+
+
 class TestSeedCommand:
     """Tests for the seed CLI command."""
 

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -773,3 +773,92 @@ class TestHookSessionFallback:
         if captured_file.exists():
             captured = captured_file.read_text()
             assert "Response for camelCase session" in captured
+
+
+class TestHookCliArgs:
+    """Test hook passes the right provenance flags to each CLI command."""
+
+    def _run_hook_with_recorder(self, tmp_path: Path) -> list[str]:
+        """Run the hook with a fake `uv` that records every CLI invocation.
+
+        The hook prepends $HOME/.local/bin to PATH and prefers `uv` over a
+        direct memory-mcp-cli, so a fake `uv` there intercepts every run_cli
+        call even on hosts where a real uv is installed (a fake
+        memory-mcp-cli in PATH loses to /opt/homebrew/bin/uv).
+        """
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "Which web framework do we use?"}],
+                    }
+                }
+            ),
+            json.dumps(
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "We use FastAPI for the API layer."}],
+                    }
+                }
+            ),
+        ]
+        transcript.write_text("\n".join(lines))
+
+        calls_file = tmp_path / "calls.txt"
+        fake_bin = tmp_path / ".local" / "bin"
+        fake_bin.mkdir(parents=True)
+        fake_uv = fake_bin / "uv"
+        fake_uv.write_text(
+            "#!/bin/bash\n"
+            "# Invoked as: uv run memory-mcp-cli <command> [options]\n"
+            "shift 2\n"
+            f'echo "$*" >> "{calls_file}"\n'
+            'if [ "$1" = "log-output" ]; then cat > /dev/null; fi\n'
+        )
+        fake_uv.chmod(0o755)
+
+        env = {
+            "HOME": str(tmp_path),
+            "PATH": "/usr/bin:/bin",
+            "MEMORY_MCP_DIR": str(tmp_path),
+        }
+        result = subprocess.run(
+            ["bash", str(HOOK_SCRIPT)],
+            input=json.dumps(
+                {
+                    "transcript_path": str(transcript),
+                    "session_id": "sess-args-test",
+                    "cwd": "/tmp/fake-project",
+                }
+            ),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert calls_file.exists(), "fake uv was never invoked"
+        return calls_file.read_text().strip().splitlines()
+
+    def test_run_mining_receives_project_but_not_session(self, tmp_path: Path) -> None:
+        """run-mining has no --session-id option; passing one aborts mining
+        with a usage error on every hook run."""
+        calls = self._run_hook_with_recorder(tmp_path)
+
+        mining_calls = [c for c in calls if c.startswith("run-mining")]
+        assert len(mining_calls) == 1
+        assert "--session-id" not in mining_calls[0]
+        assert "--project-id=/tmp/fake-project" in mining_calls[0]
+
+    def test_log_output_receives_session_and_project(self, tmp_path: Path) -> None:
+        """log-output keeps both provenance flags so mined memories can
+        inherit the session from the source log."""
+        calls = self._run_hook_with_recorder(tmp_path)
+
+        log_calls = [c for c in calls if c.startswith("log-output")]
+        assert len(log_calls) == 1
+        assert "--session-id=sess-args-test" in log_calls[0]
+        assert "--project-id=/tmp/fake-project" in log_calls[0]


### PR DESCRIPTION
## Summary
- Restores the original automatic learning loop (Stop hook → log output → mine patterns), which silently failed every session, by fixing the two hook-call bugs rather than removing the design (the approach taken on the unmerged `feature/simplify-and-analysis` branch).
- `hooks/memory-log-response.sh` passed `--session-id` to `run-mining`, which has no such option — the mining step aborted with `Error: No such option: --session-id` on every invocation (see `.mining-hook.log`). The hook now passes only `--project-id` to `run-mining`; `log-output` keeps both provenance flags.
- The `log-response` command (plugin Stop hook) parsed `session_id` from hook input but never passed it to `storage.log_output`, so hook-logged outputs and the memories mined from them were never linked to their session. It is now threaded through; mined memories inherit it from the source log per `get_recent_outputs`.

## Test plan
- [x] New regression test: hook passes `--project-id` but not `--session-id` to `run-mining` (fails on main with the exact bug, passes here)
- [x] New regression test: hook passes both flags to `log-output`
- [x] New regression test: `log-response` stores `session_id` on the logged output row (fails on main with `session_id=None`)
- [x] Full suite: 671 passed, 2 skipped
- [x] End-to-end against the real CLI with an isolated DB: hook exits 0, output row carries the session id, mining processes it (1 output, 3 patterns, 1 new memory), the mined memory row inherits the session id, and the hook log shows no usage errors