### PR TITLE
v0.8.0: learning-loop observability and utility feedback

### DIFF
--- a/.claude-plugin/skills/recall-nudge/SKILL.md
+++ b/.claude-plugin/skills/recall-nudge/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: recall-nudge
+description: This skill should be used when the user asks a retrospective question about past work or prior decisions, such as "didn't we already try this", "last time we did X", "how did we solve this before", or "have we seen this before". Nudges a call to the memory recall tool before answering from scratch, so the answer reflects what actually happened instead of a guess.
+---
+
+# Recall Nudge
+
+When the user asks about past work or prior decisions, call the memory `recall` tool first. Answer grounded in what it returns.
+
+If `recall` returns nothing, say so, then answer normally.

--- a/.planning/superpowers/plans/2026-07-01-v0.8-loop-observability-plan.md
+++ b/.planning/superpowers/plans/2026-07-01-v0.8-loop-observability-plan.md
@@ -44,6 +44,7 @@ The spec leaves seven points open. Resolutions below are design decisions of thi
 5. **`mined_approved` and decay.** Spec exempts "source != mining". `MemorySource.MINED_APPROVED` exists (`models.py:36`) for approved candidates; approval is a human signal. Resolution: decay targets `source = 'mined'` only.
 6. **Utility floor value.** Spec says "floored" without a number. Resolution: `utility_score = 0.0` (v16 default is 0.25).
 7. **Probe runs the full pipeline.** `run_mining`'s auto-promote stage processes all pending candidates, so a probe may legitimately promote unrelated real patterns that were already due. This mirrors a real run and is accepted; no skip flag is added.
+8. **Sentinel length vs `mining_min_pattern_length`.** (Found during implementation.) The original sentinel `import memory_probe_{nonce}` is 28 chars; patterns shorter than `mining_min_pattern_length` (default 30, `config.py:68`) are extracted but dropped before `mined_patterns` (`mining.py:1329`), so the probe's assert stage could never pass. Resolution: sentinel is `import memory_probe_sentinel_{nonce}` (37 chars), probe-local only — the probe must exercise the real pipeline with real thresholds, so neither the config default nor the extractor changes. `probe.py` carries a comment stating the ≥30 constraint; if a user raises the threshold past the sentinel length, the probe fails at the assert stage and `hook-check` reports it.
 
 ## Alternatives considered
 
@@ -548,7 +549,7 @@ def run_probe(storage: Storage) -> ProbeResult: ...
 Probe flow (each stage in its own try/except that returns `ProbeResult(ok=False, stage=..., error=f"{type(e).__name__}: {e}")`):
 
 1. **Pre-sweep** (idempotent, part of no stage — failures here report as `"cleanup"`): delete leftovers from any prior failed probe using the same deletions as step 5.
-2. **log**: `nonce = uuid4().hex[:8]`; `sentinel = f"import memory_probe_{nonce}"` (import-shaped so `extract_patterns` reliably mines it; short nonce so `redact_secrets` at `output_logging.py:43` never flags it); `log_id = storage.log_output(sentinel, session_id=PROBE_SESSION_ID)`.
+2. **log**: `nonce = uuid4().hex[:8]`; `sentinel = f"import memory_probe_sentinel_{nonce}"` (import-shaped so `extract_patterns` reliably mines it; 37 chars ≥ `mining_min_pattern_length` default 30 so the extractor's length filter at `mining.py:1329` keeps it — deviation 8; short nonce so `redact_secrets` at `output_logging.py:43` never flags it); `log_id = storage.log_output(sentinel, session_id=PROBE_SESSION_ID)`.
 3. **mine**: `run_mining(storage, hours=1, session_id=PROBE_SESSION_ID, record_run=False)`.
 4. **assert**: a `mined_patterns` row with `pattern LIKE '%' || nonce || '%'` exists (pattern-level is deterministic; memory creation depends on the confidence threshold, so assert it only if present).
 5. **cleanup**: `storage.delete_memory(id)` for every memory with `content LIKE '%' || nonce || '%'` (cascades vectors/tags); `DELETE FROM mined_patterns WHERE pattern LIKE ...`; `DELETE FROM output_log WHERE session_id = ?` (probe session); then verify residue is zero and put counts in `details`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Loop round-trip probe** - `hook-check` now performs a live log→mine→assert→cleanup probe
   (`--no-probe` to skip), catching wiring bugs the day they land
-- **Mining run history** - Every `run_mining` records outcomes to the new `mining_runs` table
-  (schema v18) — the DB, not logs, is the source of truth for loop health
+- **Mining run history** - Every real (non-probe) `run_mining` records outcomes to the new
+  `mining_runs` table (schema v18) — the DB, not logs, is the source of truth for loop health
 - **Learning-loop health** - `status` gains a Learning Loop section; the dashboard mining page
   shows a green/amber/red health banner
 - **Session-start staleness warning** - Bootstrap warns (once per day) when the loop hasn't

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Loop round-trip probe** - `hook-check` now performs a live log→mine→assert→cleanup probe
+  (`--no-probe` to skip), catching wiring bugs the day they land
+- **Mining run history** - Every `run_mining` records outcomes to the new `mining_runs` table
+  (schema v18) — the DB, not logs, is the source of truth for loop health
+- **Learning-loop health** - `status` gains a Learning Loop section; the dashboard mining page
+  shows a green/amber/red health banner
+- **Session-start staleness warning** - Bootstrap warns (once per day) when the loop hasn't
+  produced in 7 days or is erroring; disable with `MEMORY_MCP_LOOP_WARNINGS_ENABLED=0`
+- **Injected-memory usage tracking** - `log-response` marks injected memories used when their
+  distinctive tokens appear in responses
+- **Utility decay** - Mined memories never retrieved or used within 30 days are demoted from
+  the hot cache and utility-floored (nothing is deleted; pinned and non-mined memories exempt)
+- **recall-nudge skill** - Plugin skill nudging a `recall` call on retrospective questions
+
 ### Fixed
 
 - **Stop hook mining call** - `hooks/memory-log-response.sh` passed `--session-id` to

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ memory-mcp-cli dashboard    # Opens at http://localhost:8765
 
 ![Dashboard](docs/images/dashboard.png)
 
-Browse memories, hot cache, mining candidates, sessions, and knowledge graph.
+Browse memories, hot cache, mining candidates, sessions, and knowledge graph. The mining page shows a green/amber/red health banner tracking learning loop freshness.
 
 ## How to Use
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -210,6 +210,92 @@ Shows the current project (detected from git) and its associated memories:
 - Project-specific promoted memories
 - Useful for debugging project awareness
 
+## Learning Loop & Observability
+
+The learning loop is the system that extracts and promotes useful patterns from Claude's responses. Memory MCP tracks loop health continuously.
+
+### Mining Runs Table
+
+Every pattern extraction (`run_mining`) writes a row to the `mining_runs` table (schema v18):
+
+| Column | Description |
+|--------|-------------|
+| `started_at` | Timestamp when mining began |
+| `ended_at` | Timestamp when mining completed (NULL if failed) |
+| `patterns_extracted` | Count of patterns found |
+| `patterns_approved` | Count of patterns approved to memories |
+| `session_id` | Which session produced the mining run (or PROBE_SESSION_ID for hook-check) |
+| `status` | Success, timeout, or error summary |
+
+The table is the single source of truth for loop health — not logs. Query it to detect:
+
+- **Recent loop staleness** (no successful run in 7 days)
+- **Error spike** (pattern approval rate dropped)
+- **Extraction efficiency** (patterns_extracted vs patterns_approved ratio)
+
+### hook-check With Round-Trip Probe
+
+The `hook-check` CLI command validates hook dependencies and can optionally perform a live probe:
+
+```bash
+memory-mcp-cli hook-check              # Check deps only
+memory-mcp-cli hook-check --no-probe   # Skip live probe (faster)
+```
+
+The probe (enabled by default) runs: log → mine → extract → cleanup. Results written to `mining_runs` with `session_id = 'PROBE_SESSION_ID'`. Catching wiring bugs on the day they land.
+
+### Staleness Warnings
+
+On session start, the bootstrap hook checks loop freshness. If the loop hasn't succeeded in 7 days or is in error state, it warns (once per day):
+
+```
+⚠️  Learning loop stale — no successful runs in 7 days. Check hooks with: memory-mcp-cli hook-check
+```
+
+Disable staleness warnings with:
+
+```bash
+MEMORY_MCP_LOOP_WARNINGS_ENABLED=0
+```
+
+### Learning Loop Status Section
+
+The `status` CLI command shows Learning Loop health:
+
+```bash
+memory-mcp-cli status
+```
+
+Output includes:
+- Last successful run timestamp
+- Patterns extracted (24-hour window)
+- Mining runs table row count
+- Error summary (if any)
+
+### Injected-Memory Usage Tracking
+
+When Claude's response contains distinctive tokens from injected memories, `log-response` automatically marks those memories as "used" for helpfulness tracking.
+
+Distinctive tokens are:
+
+- **Identifiers** (CamelCase, snake_case, kebab-case with 2+ segments)
+- **Paths** (`/path/to/file`, `src/module`)
+- **Versions** (`v1.2.3`, `python3.10`)
+- **URLs** and domain names
+
+The heuristic is deliberately conservative — false positives hurt more than missed matches.
+
+### Utility Decay
+
+Mined memories (memories from pattern extraction) that are never retrieved **and** never used within 30 days enter a decay process:
+
+- **Demoted** from hot cache (if present)
+- **Utility-floored** to 0.0 (prevents re-promotion)
+- **Never deleted** — archived for reference
+- **Non-mined and pinned memories exempt**
+
+Decay runs automatically during maintenance (`run_full_cleanup`). It helps prevent clutter when patterns lose relevance.
+
 ## CLI Commands
 
 ```bash
@@ -231,6 +317,10 @@ memory-mcp-cli seed ~/project/CLAUDE.md -t project --promote
 # Consolidate similar memories
 memory-mcp-cli consolidate --dry-run
 memory-mcp-cli consolidate
+
+# Validate loop hooks and connectivity
+memory-mcp-cli hook-check
+memory-mcp-cli hook-check --no-probe
 
 # Show memory system status
 memory-mcp-cli status

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -216,22 +216,31 @@ The learning loop is the system that extracts and promotes useful patterns from 
 
 ### Mining Runs Table
 
-Every pattern extraction (`run_mining`) writes a row to the `mining_runs` table (schema v18):
+Every real (non-probe) pattern extraction (`run_mining`) writes a row to the `mining_runs` table (schema v18):
 
 | Column | Description |
 |--------|-------------|
-| `started_at` | Timestamp when mining began |
-| `ended_at` | Timestamp when mining completed (NULL if failed) |
-| `patterns_extracted` | Count of patterns found |
-| `patterns_approved` | Count of patterns approved to memories |
-| `session_id` | Which session produced the mining run (or PROBE_SESSION_ID for hook-check) |
-| `status` | Success, timeout, or error summary |
+| `id` | Primary key |
+| `started_at` | Timestamp when mining began (NOT NULL) |
+| `finished_at` | Timestamp when mining completed (NULL if it never finished) |
+| `outputs_processed` | Count of output_log rows processed (default 0) |
+| `patterns_found` | Count of patterns found (default 0) |
+| `memories_created` | Count of memories created from patterns (default 0) |
+| `error` | Error message if the run failed, else NULL |
 
-The table is the single source of truth for loop health — not logs. Query it to detect:
+The table is the single source of truth for loop health — not logs. `storage.get_loop_health()` queries it to compute the red/amber/green state and the 7-day/24-hour counters shown in `status` and the dashboard (see "Health State Rules" below).
 
-- **Recent loop staleness** (no successful run in 7 days)
-- **Error spike** (pattern approval rate dropped)
-- **Extraction efficiency** (patterns_extracted vs patterns_approved ratio)
+### Health State Rules
+
+`get_loop_health()` derives one of three states from `mining_runs`, applied in this precedence order:
+
+| State | Condition |
+|-------|-----------|
+| **red** | The 3 most recent runs (`ERROR_STREAK = 3`) all have a non-null `error` — requires at least 3 runs total |
+| **amber** | Otherwise, if there is no successful run yet, or the last successful run is older than 7 days (`STALENESS_DAYS = 7`) |
+| **green** | Otherwise |
+
+This is the single set of rules behind every health indicator in the system — the `status` CLI state row, the dashboard mining-page banner, and the SessionStart staleness warning all read the same `get_loop_health()` state.
 
 ### hook-check With Round-Trip Probe
 
@@ -242,7 +251,9 @@ memory-mcp-cli hook-check              # Check deps only
 memory-mcp-cli hook-check --no-probe   # Skip live probe (faster)
 ```
 
-The probe (enabled by default) runs: log → mine → extract → cleanup. Results written to `mining_runs` with `session_id = 'PROBE_SESSION_ID'`. Catching wiring bugs on the day they land.
+The probe (enabled by default) runs: log → mine → assert → cleanup, using a disposable sentinel that it hard-deletes afterward. It calls `run_mining(..., record_run=False)`, so **the probe never writes a `mining_runs` row** — probing intentionally does not reset the staleness clock that `get_loop_health()` uses to compute loop state. If it did, a probe run alone could mask a genuinely stale (or broken) real learning loop as healthy. The probe's own output-log row is tagged `session_id = PROBE_SESSION_ID` (a constant defined in `storage/mining_runs.py`) so it can be identified and excluded from the `outputs_24h`/`outputs_7d` counters, and cleaned up.
+
+A probe failure means a pipeline stage is actually broken — not that data is stale.
 
 ### Staleness Warnings
 
@@ -266,11 +277,17 @@ The `status` CLI command shows Learning Loop health:
 memory-mcp-cli status
 ```
 
-Output includes:
-- Last successful run timestamp
-- Patterns extracted (24-hour window)
-- Mining runs table row count
-- Error summary (if any)
+The Learning Loop table shows:
+
+| Row | Description |
+|-----|-------------|
+| State | `green`, `amber`, or `red` (see "Health State Rules" below) |
+| Outputs (24h/7d) | Count of logged outputs in the last 24 hours / 7 days (probe outputs excluded) |
+| Patterns mined (7d) | Patterns found by successful runs in the last 7 days |
+| Memories created (7d) | Memories created by successful runs in the last 7 days |
+| Last successful run | Timestamp of the most recent error-free run, or `never` |
+
+With `--json`, the `learning_loop` key returns the full health dict (`state`, `last_success_at`, `last_run_at`, `consecutive_errors`, `total_runs`, `outputs_24h`, `outputs_7d`, `patterns_7d`, `memories_7d`, `days_since_success`).
 
 ### Injected-Memory Usage Tracking
 
@@ -287,12 +304,13 @@ The heuristic is deliberately conservative — false positives hurt more than mi
 
 ### Utility Decay
 
-Mined memories (memories from pattern extraction) that are never retrieved **and** never used within 30 days enter a decay process:
+Decay targets only memories with `source = 'mined'` (auto-mined, never human-approved) that are not pinned, have never been retrieved or used, and are older than 30 days. Every other memory is untouched — approved patterns (`mined_approved`), pinned memories, retrieved/used memories, young memories, and memories from any other source are all exempt.
+
+For each qualifying memory:
 
 - **Demoted** from hot cache (if present)
 - **Utility-floored** to 0.0 (prevents re-promotion)
 - **Never deleted** — archived for reference
-- **Non-mined and pinned memories exempt**
 
 Decay runs automatically during maintenance (`run_full_cleanup`). It helps prevent clutter when patterns lose relevance.
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -228,7 +228,7 @@ Every real (non-probe) pattern extraction (`run_mining`) writes a row to the `mi
 | `memories_created` | Count of memories created from patterns (default 0) |
 | `error` | Error message if the run failed, else NULL |
 
-The table is the single source of truth for loop health — not logs. `storage.get_loop_health()` queries it to compute the red/amber/green state and the 7-day/24-hour counters shown in `status` and the dashboard (see "Health State Rules" below).
+The table is the single source of truth for loop health — not logs. `storage.get_loop_health()` queries it to compute the red/amber/green state and the 7-day patterns/memories counters shown in `status` and the dashboard; the output counters (24h/7d) come from `output_log`, not this table (see "Health State Rules" below).
 
 ### Health State Rules
 
@@ -257,10 +257,12 @@ A probe failure means a pipeline stage is actually broken — not that data is s
 
 ### Staleness Warnings
 
-On session start, the bootstrap hook checks loop freshness. If the loop hasn't succeeded in 7 days or is in error state, it warns (once per day):
+On session start, the bootstrap hook checks loop freshness. If the loop hasn't succeeded in 7 days or is in error state, it prints one of these warning lines verbatim (once per day):
 
 ```
-⚠️  Learning loop stale — no successful runs in 7 days. Check hooks with: memory-mcp-cli hook-check
+memory loop hasn't produced in {days} days — run `memory-mcp-cli hook-check`
+memory loop has never produced — run `memory-mcp-cli hook-check`
+memory loop is erroring (last 3 runs failed) — run `memory-mcp-cli hook-check`
 ```
 
 Disable staleness warnings with:
@@ -281,7 +283,7 @@ The Learning Loop table shows:
 
 | Row | Description |
 |-----|-------------|
-| State | `green`, `amber`, or `red` (see "Health State Rules" below) |
+| State | `green`, `amber`, or `red` (see "Health State Rules" above) |
 | Outputs (24h/7d) | Count of logged outputs in the last 24 hours / 7 days (probe outputs excluded) |
 | Patterns mined (7d) | Patterns found by successful runs in the last 7 days |
 | Memories created (7d) | Memories created by successful runs in the last 7 days |
@@ -304,7 +306,7 @@ The heuristic is deliberately conservative — false positives hurt more than mi
 
 ### Utility Decay
 
-Decay targets only memories with `source = 'mined'` (auto-mined, never human-approved) that are not pinned, have never been retrieved or used, and are older than 30 days. Every other memory is untouched — approved patterns (`mined_approved`), pinned memories, retrieved/used memories, young memories, and memories from any other source are all exempt.
+Decay targets only memories with `source = 'mined'` that are not pinned, have never been retrieved or used, and are older than 30 days. The protections are pinning, any retrieval, any detected use, and age under 30 days; memories from any other source are untouched. Note that approving a mined pattern does not change its source — approved patterns keep `source = 'mined'` and can still decay if they are never pinned, retrieved, or used.
 
 For each qualifying memory:
 

--- a/src/memory_mcp/cli.py
+++ b/src/memory_mcp/cli.py
@@ -14,12 +14,14 @@ from rich.console import Console
 from rich.table import Table
 
 from memory_mcp.config import Settings, find_bootstrap_files, get_settings
+from memory_mcp.logging import get_logger
 from memory_mcp.probe import run_probe
 from memory_mcp.project import get_current_project_id
 from memory_mcp.storage import MemorySource, MemoryType, Storage
 from memory_mcp.text_parsing import parse_content_into_chunks
 
 console = Console()
+log = get_logger("cli")
 
 LOOP_WARNING_STAMP_TTL_SECONDS = 24 * 60 * 60
 
@@ -264,6 +266,13 @@ def log_response(ctx: click.Context) -> None:
     storage = Storage(settings)
     try:
         storage.log_output(content, project_id=project_id, session_id=session_id)
+
+        try:
+            marked = storage.mark_used_memories(last_response)
+            if marked:
+                log.info(f"auto-marked {marked} injected memories as used")
+        except Exception as e:
+            log.warning(f"auto-mark failed (non-fatal): {e}")
     finally:
         storage.close()
 

--- a/src/memory_mcp/cli.py
+++ b/src/memory_mcp/cli.py
@@ -5,6 +5,7 @@ These commands can be called from shell scripts and Claude Code hooks.
 
 import json
 import sys
+import time
 import uuid
 from pathlib import Path
 
@@ -12,13 +13,71 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from memory_mcp.config import find_bootstrap_files, get_settings
+from memory_mcp.config import Settings, find_bootstrap_files, get_settings
 from memory_mcp.probe import run_probe
 from memory_mcp.project import get_current_project_id
 from memory_mcp.storage import MemorySource, MemoryType, Storage
 from memory_mcp.text_parsing import parse_content_into_chunks
 
 console = Console()
+
+LOOP_WARNING_STAMP_TTL_SECONDS = 24 * 60 * 60
+
+
+def _loop_warning_line(settings: Settings) -> str | None:
+    """Build a one-line staleness/error warning for the learning loop, if due.
+
+    Rate-limited to once per 24h via a stamp file next to the database, so
+    that repeated `bootstrap` invocations (e.g. one per Claude Code session)
+    don't spam the same warning. The stamp is only touched when a warning is
+    actually emitted, so the first stale/erroring day always fires
+    immediately once the rate limit from the prior warning has expired.
+
+    Args:
+        settings: Active configuration, used to check the feature flag and
+            locate the database (and therefore the stamp file).
+
+    Returns:
+        The warning line to print, or None if the loop is healthy, warnings
+        are disabled, the rate limit hasn't elapsed, or any internal error
+        occurred while computing loop health. A broken warning system must
+        never break session start, so all errors degrade to silence.
+    """
+    try:
+        if not settings.loop_warnings_enabled:
+            return None
+
+        stamp_path = Path(settings.db_path).parent / "loop-warning.stamp"
+        if stamp_path.exists():
+            age_seconds = time.time() - stamp_path.stat().st_mtime
+            if age_seconds < LOOP_WARNING_STAMP_TTL_SECONDS:
+                return None
+
+        storage = Storage(settings)
+        try:
+            health = storage.get_loop_health()
+        finally:
+            storage.close()
+
+        state = health.get("state")
+        if state == "red":
+            line = "memory loop is erroring (last 3 runs failed) — run `memory-mcp-cli hook-check`"
+        elif state == "amber":
+            days = health.get("days_since_success")
+            if days is None:
+                line = "memory loop has never produced — run `memory-mcp-cli hook-check`"
+            else:
+                line = (
+                    f"memory loop hasn't produced in {days} days — run `memory-mcp-cli hook-check`"
+                )
+        else:
+            return None
+
+        stamp_path.parent.mkdir(parents=True, exist_ok=True)
+        stamp_path.touch()
+        return line
+    except Exception:
+        return None
 
 
 @click.group()
@@ -507,6 +566,14 @@ def bootstrap(
         # JSON output for scripting
         memory-mcp-cli --json bootstrap
     """
+    # Loop staleness warning: printed first (prepend), before the empty-repo
+    # early return and before the quiet gate, so it reaches hook stdout (the
+    # injected session context) even under `-q`.
+    settings = get_settings()
+    warning = _loop_warning_line(settings)
+    if warning:
+        click.echo(warning)
+
     use_json = ctx.obj["json"]
     root = Path(root_path).expanduser().resolve()
 
@@ -542,7 +609,6 @@ def bootstrap(
 
     mem_type = MemoryType(memory_type)
     tag_list = list(tags) if tags else None
-    settings = get_settings()
 
     storage = Storage(settings)
     try:

--- a/src/memory_mcp/cli.py
+++ b/src/memory_mcp/cli.py
@@ -575,15 +575,20 @@ def bootstrap(
         # JSON output for scripting
         memory-mcp-cli --json bootstrap
     """
-    # Loop staleness warning: printed first (prepend), before the empty-repo
-    # early return and before the quiet gate, so it reaches hook stdout (the
-    # injected session context) even under `-q`.
+    # Loop staleness warning: computed first (before the empty-repo early
+    # return and before the quiet gate) so the rate-limit stamp is touched
+    # on every invocation that surfaces a warning, regardless of output
+    # mode. Plain mode echoes it immediately, ahead of the payload, so it
+    # reaches hook stdout (the injected session context) even under `-q`.
+    # JSON mode never echoes it as bare text - doing so would prepend
+    # unparseable text before the JSON payload, breaking `| jq` consumers -
+    # instead it's folded into the payload's "loop_warning" key below.
     settings = get_settings()
     warning = _loop_warning_line(settings)
-    if warning:
+    use_json = ctx.obj["json"]
+    if warning and not use_json:
         click.echo(warning)
 
-    use_json = ctx.obj["json"]
     root = Path(root_path).expanduser().resolve()
 
     # Determine files to process
@@ -609,6 +614,7 @@ def bootstrap(
                         "hot_cache_promoted": 0,
                         "errors": [],
                         "message": message,
+                        "loop_warning": warning,
                     }
                 )
             )
@@ -634,7 +640,7 @@ def bootstrap(
         return
 
     if use_json:
-        click.echo(json.dumps(result))
+        click.echo(json.dumps({**result, "loop_warning": warning}))
     else:
         console.print("[bold]Bootstrap Results[/bold]")
         console.print(f"  Files processed: [cyan]{result.get('files_processed', 0)}[/cyan]")

--- a/src/memory_mcp/cli.py
+++ b/src/memory_mcp/cli.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.table import Table
 
 from memory_mcp.config import find_bootstrap_files, get_settings
+from memory_mcp.probe import run_probe
 from memory_mcp.project import get_current_project_id
 from memory_mcp.storage import MemorySource, MemoryType, Storage
 from memory_mcp.text_parsing import parse_content_into_chunks
@@ -902,8 +903,13 @@ def status(ctx: click.Context) -> None:
 
 
 @cli.command("hook-check")
+@click.option(
+    "--no-probe",
+    is_flag=True,
+    help="Skip the learning-loop round-trip probe",
+)
 @click.pass_context
-def hook_check(ctx: click.Context) -> None:
+def hook_check(ctx: click.Context, no_probe: bool) -> None:
     """Check hook dependencies and database connectivity.
 
     Validates that the memory-mcp hook can run successfully:
@@ -911,6 +917,10 @@ def hook_check(ctx: click.Context) -> None:
     - jq command is available
     - Database is accessible and writable
     - Hook script exists
+    - Learning-loop round trip works (log -> mine -> storage)
+
+    The round-trip probe only runs when the database check passed - a probe
+    against a broken database is noise, not signal.
 
     Examples:
 
@@ -919,6 +929,9 @@ def hook_check(ctx: click.Context) -> None:
 
         # JSON output for scripting
         memory-mcp-cli --json hook-check
+
+        # Skip the round-trip probe
+        memory-mcp-cli hook-check --no-probe
     """
     import shutil
 
@@ -941,13 +954,26 @@ def hook_check(ctx: click.Context) -> None:
 
     # Check database
     settings = get_settings()
+    database_ok = False
+    storage = None
     try:
         storage = Storage(settings)
         stats = storage.get_stats()
-        storage.close()
+        database_ok = True
         checks.append(("database", True, f"{stats['total_memories']} memories"))
     except Exception as e:
         checks.append(("database", False, str(e)))
+
+    # Round-trip probe - only meaningful once the database is known-good.
+    if database_ok and not no_probe:
+        result = run_probe(storage)
+        if result.ok:
+            checks.append(("loop_probe", True, "round trip ok"))
+        else:
+            checks.append(("loop_probe", False, f"stage={result.stage}: {result.error}"))
+
+    if storage is not None:
+        storage.close()
 
     # Check hook script
     hook_script = Path(__file__).parent.parent.parent / "hooks" / "memory-log-response.sh"
@@ -990,7 +1016,9 @@ def hook_check(ctx: click.Context) -> None:
             console.print("\n[green]All checks passed![/green]")
         else:
             console.print("\n[red]Some checks failed. Fix the issues above.[/red]")
-            raise SystemExit(1)
+
+    if not all_ok:
+        raise SystemExit(1)
 
 
 @cli.command("import-beads")

--- a/src/memory_mcp/cli.py
+++ b/src/memory_mcp/cli.py
@@ -811,6 +811,7 @@ def status(ctx: click.Context) -> None:
         hot_memories = storage.get_hot_memories()
         metrics = storage.get_hot_cache_metrics()
         memory_stats = storage.get_stats()
+        health = storage.get_loop_health()
 
         if use_json:
             click.echo(
@@ -823,6 +824,7 @@ def status(ctx: click.Context) -> None:
                             {"id": m.id, "content": m.content[:100], "type": m.memory_type.value}
                             for m in hot_memories
                         ],
+                        "learning_loop": health,
                     }
                 )
             )
@@ -855,6 +857,23 @@ def status(ctx: click.Context) -> None:
             overview_table.add_row("By source", source_str)
 
         console.print(overview_table)
+
+        # Learning loop health
+        console.print("\n[bold]Learning Loop:[/bold]")
+        loop_table = Table(show_header=False, box=None)
+        loop_table.add_column("Metric", style="dim")
+        loop_table.add_column("Value", style="bold")
+
+        state_color = {"green": "green", "amber": "yellow", "red": "red"}.get(
+            health["state"], "white"
+        )
+        loop_table.add_row("State", f"[{state_color}]{health['state']}[/{state_color}]")
+        loop_table.add_row("Outputs (24h/7d)", f"{health['outputs_24h']}/{health['outputs_7d']}")
+        loop_table.add_row("Patterns mined (7d)", str(health["patterns_7d"]))
+        loop_table.add_row("Memories created (7d)", str(health["memories_7d"]))
+        loop_table.add_row("Last successful run", health["last_success_at"] or "never")
+
+        console.print(loop_table)
 
         # Hot cache stats
         console.print("\n[bold]Hot Cache Metrics:[/bold]")

--- a/src/memory_mcp/config.py
+++ b/src/memory_mcp/config.py
@@ -327,6 +327,10 @@ class Settings(BaseSettings):
         default=True,
         description="Show warning on startup if Stop hook not configured (for pattern mining)",
     )
+    loop_warnings_enabled: bool = Field(
+        default=True,
+        description="Warn at session start when the learning loop is stale or erroring",
+    )
 
     # Semantic clustering for display (RePo-inspired cognitive load reduction)
     clustering_display_enabled: bool = Field(

--- a/src/memory_mcp/dashboard/app.py
+++ b/src/memory_mcp/dashboard/app.py
@@ -12,6 +12,7 @@ from fastapi.templating import Jinja2Templates
 from memory_mcp import __version__
 from memory_mcp.config import get_settings
 from memory_mcp.storage import MemorySource, MemoryType, PatternStatus, Storage
+from memory_mcp.storage.mining_runs import PROBE_SESSION_ID
 
 # Template directory
 TEMPLATE_DIR = Path(__file__).parent / "templates"
@@ -408,16 +409,24 @@ async def api_hot_cache_list(request: Request) -> HTMLResponse:
 
 def _get_mining_stats(s: Storage) -> dict:
     """Get mining statistics."""
-    # Count output logs
-    output_count = s._conn.execute("SELECT COUNT(*) FROM output_log").fetchone()[0]
-    # Count mined patterns by status
-    pattern_stats = s._conn.execute(
-        """
-        SELECT status, COUNT(*) as count
-        FROM mined_patterns
-        GROUP BY status
-        """
-    ).fetchall()
+    with s._connection() as conn:
+        # Count output logs, excluding leftover probe rows (same filter the
+        # loop-health queries use) so a failed probe doesn't inflate this count.
+        output_count = conn.execute(
+            """
+            SELECT COUNT(*) FROM output_log
+            WHERE session_id IS NULL OR session_id != ?
+            """,
+            (PROBE_SESSION_ID,),
+        ).fetchone()[0]
+        # Count mined patterns by status
+        pattern_stats = conn.execute(
+            """
+            SELECT status, COUNT(*) as count
+            FROM mined_patterns
+            GROUP BY status
+            """
+        ).fetchall()
     stats = {row["status"]: row["count"] for row in pattern_stats}
     return {
         "output_count": output_count,
@@ -441,6 +450,7 @@ async def mining_page(request: Request) -> HTMLResponse:
         {
             "mining_stats": mining_stats,
             "patterns": patterns[:50],  # Limit display
+            "loop_health": s.get_loop_health(),
             "active_page": "mining",
         },
     )

--- a/src/memory_mcp/dashboard/app.py
+++ b/src/memory_mcp/dashboard/app.py
@@ -528,19 +528,19 @@ async def api_reject_pattern(pattern_id: int, request: Request) -> HTMLResponse:
 
 def _get_injection_stats(s: Storage) -> dict:
     """Get injection statistics."""
-    conn = s._conn
-    today = conn.execute(
-        "SELECT COUNT(*) FROM injection_log WHERE injected_at >= date('now')"
-    ).fetchone()[0]
-    week = conn.execute(
-        "SELECT COUNT(*) FROM injection_log WHERE injected_at >= date('now', '-7 days')"
-    ).fetchone()[0]
-    hot_cache = conn.execute(
-        "SELECT COUNT(*) FROM injection_log WHERE resource = 'hot-cache'"
-    ).fetchone()[0]
-    working_set = conn.execute(
-        "SELECT COUNT(*) FROM injection_log WHERE resource = 'working-set'"
-    ).fetchone()[0]
+    with s._connection() as conn:
+        today = conn.execute(
+            "SELECT COUNT(*) FROM injection_log WHERE injected_at >= date('now')"
+        ).fetchone()[0]
+        week = conn.execute(
+            "SELECT COUNT(*) FROM injection_log WHERE injected_at >= date('now', '-7 days')"
+        ).fetchone()[0]
+        hot_cache = conn.execute(
+            "SELECT COUNT(*) FROM injection_log WHERE resource = 'hot-cache'"
+        ).fetchone()[0]
+        working_set = conn.execute(
+            "SELECT COUNT(*) FROM injection_log WHERE resource = 'working-set'"
+        ).fetchone()[0]
     return {
         "today": today,
         "week": week,
@@ -557,7 +557,6 @@ def _get_injections(
     offset: int = 0,
 ) -> list[dict]:
     """Get recent injections with memory content."""
-    conn = s._conn
     params: list = [f"-{days} days"]
     resource_filter = ""
     if resource:
@@ -565,19 +564,20 @@ def _get_injections(
         params.append(resource)
     params.extend([limit, offset])
 
-    rows = conn.execute(
-        f"""
-        SELECT il.id, il.memory_id, il.resource, il.injected_at, il.session_id,
-               m.content
-        FROM injection_log il
-        LEFT JOIN memories m ON m.id = il.memory_id
-        WHERE il.injected_at >= datetime('now', ?)
-        {resource_filter}
-        ORDER BY il.injected_at DESC
-        LIMIT ? OFFSET ?
-        """,
-        params,
-    ).fetchall()
+    with s._connection() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT il.id, il.memory_id, il.resource, il.injected_at, il.session_id,
+                   m.content
+            FROM injection_log il
+            LEFT JOIN memories m ON m.id = il.memory_id
+            WHERE il.injected_at >= datetime('now', ?)
+            {resource_filter}
+            ORDER BY il.injected_at DESC
+            LIMIT ? OFFSET ?
+            """,
+            params,
+        ).fetchall()
     return [dict(row) for row in rows]
 
 

--- a/src/memory_mcp/dashboard/templates/base.html
+++ b/src/memory_mcp/dashboard/templates/base.html
@@ -63,6 +63,23 @@
             opacity: 0;
             transition: opacity 300ms ease-out;
         }
+
+        /* Learning-loop health banner (mining page) */
+        .loop-banner-green {
+            background-color: rgba(34, 197, 94, 0.1);
+            border-color: rgba(34, 197, 94, 0.3);
+            color: #4ade80;
+        }
+        .loop-banner-amber {
+            background-color: rgba(245, 158, 11, 0.1);
+            border-color: rgba(245, 158, 11, 0.3);
+            color: #fbbf24;
+        }
+        .loop-banner-red {
+            background-color: rgba(239, 68, 68, 0.1);
+            border-color: rgba(239, 68, 68, 0.3);
+            color: #f87171;
+        }
     </style>
 </head>
 <body class="bg-dark-950 text-gray-100 min-h-screen">

--- a/src/memory_mcp/dashboard/templates/mining.html
+++ b/src/memory_mcp/dashboard/templates/mining.html
@@ -31,6 +31,25 @@
         </button>
     </div>
 
+    <!-- Loop Health Banner -->
+    <div class="loop-banner loop-banner-{{ loop_health.state }} rounded-lg border p-4 text-sm font-medium">
+        {% if loop_health.state == "green" %}
+            {% if loop_health.days_since_success == 0 %}
+                Loop healthy — last produced today
+            {% else %}
+                Loop healthy — last produced {{ loop_health.days_since_success }} day{% if loop_health.days_since_success != 1 %}s{% endif %} ago
+            {% endif %}
+        {% elif loop_health.state == "amber" %}
+            {% if loop_health.days_since_success is none %}
+                No successful mining run yet — run <code>memory-mcp-cli hook-check</code>
+            {% else %}
+                No successful mining run in {{ loop_health.days_since_success }} days — run <code>memory-mcp-cli hook-check</code>
+            {% endif %}
+        {% elif loop_health.state == "red" %}
+            Recent mining runs are failing — run <code>memory-mcp-cli hook-check</code>
+        {% endif %}
+    </div>
+
     <!-- Mining Stats -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div class="bg-dark-900 rounded-lg border border-gray-800 p-4">

--- a/src/memory_mcp/migrations.py
+++ b/src/memory_mcp/migrations.py
@@ -12,7 +12,7 @@ from memory_mcp.logging import get_logger
 log = get_logger("migrations")
 
 # Current schema version - increment when making breaking changes
-SCHEMA_VERSION = 17
+SCHEMA_VERSION = 18
 
 SCHEMA = """
 -- Schema version tracking
@@ -544,6 +544,23 @@ def migrate_v16_to_v17(conn: sqlite3.Connection) -> None:
     log.info("Added memory_id column to mined_patterns for exact-match promotion (v17)")
 
 
+def migrate_v17_to_v18(conn: sqlite3.Connection) -> None:
+    """Add mining_runs table for learning-loop observability (v18)."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS mining_runs (
+            id INTEGER PRIMARY KEY,
+            started_at TEXT NOT NULL,
+            finished_at TEXT,
+            outputs_processed INTEGER DEFAULT 0,
+            patterns_found INTEGER DEFAULT 0,
+            memories_created INTEGER DEFAULT 0,
+            error TEXT
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_mining_runs_started ON mining_runs(started_at)")
+    log.info("Added mining_runs table (v18)")
+
+
 # ========== Migration Runner ==========
 
 
@@ -581,6 +598,8 @@ def run_migrations(conn: sqlite3.Connection, from_version: int, settings: Settin
         migrate_v15_to_v16(conn)
     if from_version < 17:
         migrate_v16_to_v17(conn)
+    if from_version < 18:
+        migrate_v17_to_v18(conn)
 
 
 def check_schema_version(conn: sqlite3.Connection) -> None:

--- a/src/memory_mcp/mining.py
+++ b/src/memory_mcp/mining.py
@@ -3,11 +3,23 @@
 import logging
 import re
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
 from memory_mcp.embeddings import content_hash
 from memory_mcp.storage import MemoryType, Storage
+
+
+def _utc_now_str() -> str:
+    """Return the current UTC time formatted for `mining_runs` timestamp columns.
+
+    Returns:
+        Current UTC time as "%Y-%m-%d %H:%M:%S", matching the format used by
+        `storage.record_mining_run` and `storage.get_loop_health`.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
 
 # Patterns that indicate potentially sensitive content - never auto-approve
 SENSITIVE_PATTERNS = (
@@ -1241,7 +1253,13 @@ def _get_memory_type_for_pattern(pattern_type: str) -> MemoryType:
     return MemoryType.PATTERN
 
 
-def run_mining(storage: Storage, hours: int = 24, project_id: str | None = None) -> dict:
+def run_mining(
+    storage: Storage,
+    hours: int = 24,
+    project_id: str | None = None,
+    session_id: str | None = None,
+    record_run: bool = True,
+) -> dict:
     """Run pattern mining on recent outputs.
 
     Args:
@@ -1249,6 +1267,11 @@ def run_mining(storage: Storage, hours: int = 24, project_id: str | None = None)
         hours: How many hours of logs to process.
         project_id: If provided, only mine logs from this project.
                     This prevents cross-project pattern leakage.
+        session_id: If provided, only mine logs from this exact session.
+                    Used by the round-trip probe to scope to its own output.
+        record_run: If True (default), persist the outcome of this run via
+                    `storage.record_mining_run`. The probe passes False so
+                    probe runs never pollute loop-health accounting.
 
     Returns statistics about patterns found and stored.
 
@@ -1260,127 +1283,153 @@ def run_mining(storage: Storage, hours: int = 24, project_id: str | None = None)
         Each mined memory inherits the project_id from its source log, not the
         current session. This prevents cross-project pollution when mining logs
         from multiple projects.
+
+    Raises:
+        Exception: Re-raises any exception from the mining body after
+            recording it (when `record_run` is True). Recording happens
+            outside the mined-transaction path so a recording failure never
+            corrupts mining results.
     """
     from memory_mcp.storage import MemorySource
 
-    outputs = storage.get_recent_outputs(hours=hours, project_id=project_id)
-    settings = storage.settings
-
-    total_patterns = 0
-    new_memories = 0
-    updated_patterns = 0
-    promoted_to_hot = 0
-
-    # Track entity memories for cross-linking
-    entity_memories: list[
-        tuple[int, str, int | None]
-    ] = []  # (memory_id, pattern_type, source_log_id)
-
-    for log_id, content, _, log_project_id, log_session_id in outputs:
-        patterns = extract_patterns(
-            content,
-            ner_enabled=settings.ner_enabled,
-            ner_confidence=settings.ner_confidence_threshold,
+    started_at = _utc_now_str()
+    try:
+        outputs = storage.get_recent_outputs(
+            hours=hours, project_id=project_id, session_id=session_id
         )
-        total_patterns += len(patterns)
+        settings = storage.settings
 
-        for pattern in patterns:
-            hash_val = content_hash(pattern.pattern)
-            is_existing = storage.mined_pattern_exists(hash_val)
+        total_patterns = 0
+        new_memories = 0
+        updated_patterns = 0
+        promoted_to_hot = 0
 
-            # SECURITY: Skip patterns that might contain sensitive data
-            if _may_contain_secrets(pattern.pattern):
-                continue
+        # Track entity memories for cross-linking
+        entity_memories: list[
+            tuple[int, str, int | None]
+        ] = []  # (memory_id, pattern_type, source_log_id)
 
-            # Skip short fragments (too short to be useful knowledge)
-            if len(pattern.pattern) < settings.mining_min_pattern_length:
-                continue
+        for log_id, content, _, log_project_id, log_session_id in outputs:
+            patterns = extract_patterns(
+                content,
+                ner_enabled=settings.ner_enabled,
+                ner_confidence=settings.ner_confidence_threshold,
+            )
+            total_patterns += len(patterns)
 
-            if is_existing:
-                # Update occurrence count in mined_patterns table
-                updated_patterns += 1
-                storage.upsert_mined_pattern(
-                    pattern.pattern,
-                    pattern.pattern_type.value,
-                    source_log_id=log_id,
-                    confidence=pattern.confidence,
-                )
-            else:
-                # New pattern - store as memory immediately if confidence is sufficient
-                # Skip low-value categories (command, snippet) - they go to mined_patterns only
-                created_memory_id = None
-                skip_memory_storage = pattern.pattern_type.value in ("command", "snippet")
+            for pattern in patterns:
+                hash_val = content_hash(pattern.pattern)
+                is_existing = storage.mined_pattern_exists(hash_val)
 
-                if (
-                    not skip_memory_storage
-                    and pattern.confidence >= settings.mining_auto_approve_confidence
-                ):
-                    mem_type = _get_memory_type_for_pattern(pattern.pattern_type.value)
+                # SECURITY: Skip patterns that might contain sensitive data
+                if _may_contain_secrets(pattern.pattern):
+                    continue
 
-                    # Use project_id and session_id from source log, not current session
-                    # This prevents cross-project pollution
-                    memory_id, is_new = storage.store_memory(
-                        content=pattern.pattern,
-                        memory_type=mem_type,
-                        source=MemorySource.MINED,
-                        tags=["mined"],
-                        project_id=log_project_id,
-                        session_id=log_session_id,
+                # Skip short fragments (too short to be useful knowledge)
+                if len(pattern.pattern) < settings.mining_min_pattern_length:
+                    continue
+
+                if is_existing:
+                    # Update occurrence count in mined_patterns table
+                    updated_patterns += 1
+                    storage.upsert_mined_pattern(
+                        pattern.pattern,
+                        pattern.pattern_type.value,
                         source_log_id=log_id,
+                        confidence=pattern.confidence,
+                    )
+                else:
+                    # New pattern - store as memory immediately if confidence is sufficient
+                    # Skip low-value categories (command, snippet) - they go to mined_patterns only
+                    created_memory_id = None
+                    skip_memory_storage = pattern.pattern_type.value in ("command", "snippet")
+
+                    if (
+                        not skip_memory_storage
+                        and pattern.confidence >= settings.mining_auto_approve_confidence
+                    ):
+                        mem_type = _get_memory_type_for_pattern(pattern.pattern_type.value)
+
+                        # Use project_id and session_id from source log, not current session
+                        # This prevents cross-project pollution
+                        memory_id, is_new = storage.store_memory(
+                            content=pattern.pattern,
+                            memory_type=mem_type,
+                            source=MemorySource.MINED,
+                            tags=["mined"],
+                            project_id=log_project_id,
+                            session_id=log_session_id,
+                            source_log_id=log_id,
+                        )
+
+                        if is_new:
+                            new_memories += 1
+                            created_memory_id = memory_id
+
+                        # Track entity patterns for knowledge graph linking
+                        # Note: Track even when is_new=False (merged with existing) - the memory
+                        # exists and should be linked to other memories from the same output log
+                        if pattern.pattern_type.value in (
+                            "entity_technology",
+                            "entity_decision",
+                        ):
+                            entity_memories.append((memory_id, pattern.pattern_type.value, log_id))
+
+                    # Track in mined_patterns for occurrence counting
+                    pattern_id = storage.upsert_mined_pattern(
+                        pattern.pattern,
+                        pattern.pattern_type.value,
+                        source_log_id=log_id,
+                        confidence=pattern.confidence,
                     )
 
-                    if is_new:
-                        new_memories += 1
-                        created_memory_id = memory_id
+                    # Link pattern to its memory for exact-match promotion
+                    if created_memory_id is not None:
+                        storage.link_pattern_to_memory(pattern_id, created_memory_id)
 
-                    # Track entity patterns for knowledge graph linking
-                    # Note: Track even when is_new=False (merged with existing) - the memory
-                    # exists and should be linked to other memories from the same output log
-                    if pattern.pattern_type.value in (
-                        "entity_technology",
-                        "entity_decision",
-                    ):
-                        entity_memories.append((memory_id, pattern.pattern_type.value, log_id))
+        # Promote high-occurrence patterns to hot cache
+        if settings.mining_auto_approve_enabled:
+            from memory_mcp.storage import PatternStatus
 
-                # Track in mined_patterns for occurrence counting
-                pattern_id = storage.upsert_mined_pattern(
-                    pattern.pattern,
-                    pattern.pattern_type.value,
-                    source_log_id=log_id,
-                    confidence=pattern.confidence,
-                )
+            candidates = storage.get_promotion_candidates(threshold=1, status=PatternStatus.PENDING)
+            for candidate in candidates:
+                if candidate.occurrence_count < settings.mining_auto_approve_occurrences:
+                    continue
 
-                # Link pattern to its memory for exact-match promotion
-                if created_memory_id is not None:
-                    storage.link_pattern_to_memory(pattern_id, created_memory_id)
+                # Prefer exact match via linked memory_id, fallback to semantic search
+                # (semantic search needed for patterns created before v17 migration)
+                memory_id_to_promote = candidate.memory_id
+                if memory_id_to_promote is None:
+                    memories = storage.recall(candidate.pattern, limit=1, threshold=0.95).memories
+                    memory_id_to_promote = memories[0].id if memories else None
 
-    # Promote high-occurrence patterns to hot cache
-    if settings.mining_auto_approve_enabled:
-        from memory_mcp.storage import PatternStatus
+                if memory_id_to_promote is not None and storage.promote_to_hot(
+                    memory_id_to_promote
+                ):
+                    promoted_to_hot += 1
 
-        candidates = storage.get_promotion_candidates(threshold=1, status=PatternStatus.PENDING)
-        for candidate in candidates:
-            if candidate.occurrence_count < settings.mining_auto_approve_occurrences:
-                continue
+        # Create knowledge graph links for entities
+        entity_links_created = _create_entity_links(storage, entity_memories)
 
-            # Prefer exact match via linked memory_id, fallback to semantic search
-            # (semantic search needed for patterns created before v17 migration)
-            memory_id_to_promote = candidate.memory_id
-            if memory_id_to_promote is None:
-                memories = storage.recall(candidate.pattern, limit=1, threshold=0.95).memories
-                memory_id_to_promote = memories[0].id if memories else None
+        stats = {
+            "outputs_processed": len(outputs),
+            "patterns_found": total_patterns,
+            "new_memories": new_memories,
+            "updated_patterns": updated_patterns,
+            "promoted_to_hot": promoted_to_hot,
+            "entity_links_created": entity_links_created,
+        }
+    except Exception as e:
+        if record_run:
+            storage.record_mining_run(
+                started_at=started_at,
+                finished_at=_utc_now_str(),
+                stats={},
+                error=f"{type(e).__name__}: {e}",
+            )
+        raise
 
-            if memory_id_to_promote is not None and storage.promote_to_hot(memory_id_to_promote):
-                promoted_to_hot += 1
+    if record_run:
+        storage.record_mining_run(started_at=started_at, finished_at=_utc_now_str(), stats=stats)
 
-    # Create knowledge graph links for entities
-    entity_links_created = _create_entity_links(storage, entity_memories)
-
-    return {
-        "outputs_processed": len(outputs),
-        "patterns_found": total_patterns,
-        "new_memories": new_memories,
-        "updated_patterns": updated_patterns,
-        "promoted_to_hot": promoted_to_hot,
-        "entity_links_created": entity_links_created,
-    }
+    return stats

--- a/src/memory_mcp/probe.py
+++ b/src/memory_mcp/probe.py
@@ -1,0 +1,159 @@
+"""Learning-loop round-trip probe.
+
+Runs the real logging -> mining -> storage pipeline end-to-end with a
+disposable sentinel, then hard-deletes every artifact it created. A probe
+failure means a stage of the pipeline is actually broken (a "wiring bug"),
+not that data is stale - `run_mining` with `record_run=False` never writes
+a `mining_runs` row, so probing never resets the staleness clock used by
+`storage.get_loop_health`.
+
+This module is intentionally CLI-free; a future task wires `run_probe` into
+the hook-check CLI command.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+from memory_mcp.mining import run_mining
+from memory_mcp.storage import Storage
+from memory_mcp.storage.mining_runs import PROBE_SESSION_ID
+
+
+@dataclass
+class ProbeResult:
+    """Outcome of a single round-trip probe run.
+
+    Attributes:
+        ok: True if every stage completed and cleanup left zero residue.
+        stage: Empty string on success; otherwise the stage that failed -
+            one of "log", "mine", "assert", "cleanup".
+        error: `f"{type(e).__name__}: {e}"` for the exception that caused
+            the failure, or None on success.
+        details: Diagnostic counts. On success, cleanup counts under the
+            keys "memories_deleted", "patterns_deleted", "outputs_deleted".
+    """
+
+    ok: bool
+    stage: str
+    error: str | None = None
+    details: dict = field(default_factory=dict)
+
+
+def _cleanup(storage: Storage, nonce: str) -> dict:
+    """Delete every probe artifact matching `nonce` and verify zero residue.
+
+    Memories are removed via `storage.delete_memory` (not raw SQL) so the
+    vector and tag cascades run. `mined_patterns` and `output_log` rows have
+    no dependents, so they're removed directly.
+
+    Args:
+        storage: Storage instance to clean up.
+        nonce: The probe's content nonce, used to scope pattern/memory
+            deletes via `LIKE '%' || nonce || '%'`.
+
+    Returns:
+        Dict with keys `memories_deleted`, `patterns_deleted`,
+        `outputs_deleted` giving the counts removed.
+
+    Raises:
+        AssertionError: If residue remains after cleanup.
+    """
+    like_nonce = f"%{nonce}%"
+
+    with storage._connection() as conn:
+        memory_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT id FROM memories WHERE content LIKE ?", (like_nonce,)
+            ).fetchall()
+        ]
+    memories_deleted = sum(1 for mid in memory_ids if storage.delete_memory(mid))
+
+    with storage.transaction() as conn:
+        patterns_deleted = conn.execute(
+            "DELETE FROM mined_patterns WHERE pattern LIKE ?", (like_nonce,)
+        ).rowcount
+        outputs_deleted = conn.execute(
+            "DELETE FROM output_log WHERE session_id = ?", (PROBE_SESSION_ID,)
+        ).rowcount
+
+    with storage._connection() as conn:
+        residue = (
+            conn.execute(
+                "SELECT COUNT(*) FROM output_log WHERE session_id = ?", (PROBE_SESSION_ID,)
+            ).fetchone()[0],
+            conn.execute(
+                "SELECT COUNT(*) FROM mined_patterns WHERE pattern LIKE ?", (like_nonce,)
+            ).fetchone()[0],
+            conn.execute(
+                "SELECT COUNT(*) FROM memories WHERE content LIKE ?", (like_nonce,)
+            ).fetchone()[0],
+        )
+    assert residue == (0, 0, 0), f"probe cleanup left residue: {residue}"
+
+    return {
+        "memories_deleted": memories_deleted,
+        "patterns_deleted": patterns_deleted,
+        "outputs_deleted": outputs_deleted,
+    }
+
+
+def run_probe(storage: Storage) -> ProbeResult:
+    """Run the learning-loop round trip and report whether wiring is intact.
+
+    Logs a disposable, import-shaped sentinel, mines it with the real
+    pipeline, asserts it was captured as a mined pattern, then deletes every
+    artifact it created. A clean pre-sweep runs first so leftovers from a
+    prior failed probe never accumulate or get mistaken for real data.
+
+    Args:
+        storage: Storage instance to probe.
+
+    Returns:
+        A `ProbeResult`. On success, `ok=True`, `stage=""`, and `details`
+        holds the cleanup counts. On failure, `ok=False`, `stage` names the
+        failing stage ("log", "mine", "assert", or "cleanup" - pre-sweep
+        failures also report as "cleanup"), and `error` describes the
+        exception.
+    """
+    nonce = uuid4().hex[:8]
+
+    try:
+        _cleanup(storage, nonce)
+    except Exception as e:  # noqa: BLE001 - reported via ProbeResult, not raised
+        return ProbeResult(ok=False, stage="cleanup", error=f"{type(e).__name__}: {e}")
+
+    try:
+        # Constraint: the sentinel must stay >= mining_min_pattern_length
+        # (default 30) characters, or the extractor's length filter in
+        # run_mining drops the pattern before mined_patterns and the assert
+        # stage can never pass. This sentinel is 37 chars (8-char nonce). If
+        # a user raises the threshold past the sentinel length, the probe
+        # fails at the assert stage and hook-check reports it.
+        sentinel = f"import memory_probe_sentinel_{nonce}"
+        storage.log_output(sentinel, session_id=PROBE_SESSION_ID)
+    except Exception as e:  # noqa: BLE001
+        return ProbeResult(ok=False, stage="log", error=f"{type(e).__name__}: {e}")
+
+    try:
+        run_mining(storage, hours=1, session_id=PROBE_SESSION_ID, record_run=False)
+    except Exception as e:  # noqa: BLE001
+        return ProbeResult(ok=False, stage="mine", error=f"{type(e).__name__}: {e}")
+
+    try:
+        with storage._connection() as conn:
+            pattern_row = conn.execute(
+                "SELECT COUNT(*) FROM mined_patterns WHERE pattern LIKE ?", (f"%{nonce}%",)
+            ).fetchone()
+        assert pattern_row[0] > 0, f"no mined_patterns row for nonce {nonce!r}"
+    except Exception as e:  # noqa: BLE001
+        return ProbeResult(ok=False, stage="assert", error=f"{type(e).__name__}: {e}")
+
+    try:
+        details = _cleanup(storage, nonce)
+    except Exception as e:  # noqa: BLE001
+        return ProbeResult(ok=False, stage="cleanup", error=f"{type(e).__name__}: {e}")
+
+    return ProbeResult(ok=True, stage="", details=details)

--- a/src/memory_mcp/probe.py
+++ b/src/memory_mcp/probe.py
@@ -20,6 +20,8 @@ from memory_mcp.mining import run_mining
 from memory_mcp.storage import Storage
 from memory_mcp.storage.mining_runs import PROBE_SESSION_ID
 
+SENTINEL_PREFIX = "memory_probe_sentinel_"
+
 
 @dataclass
 class ProbeResult:
@@ -41,8 +43,8 @@ class ProbeResult:
     details: dict = field(default_factory=dict)
 
 
-def _cleanup(storage: Storage, nonce: str) -> dict:
-    """Delete every probe artifact matching `nonce` and verify zero residue.
+def _cleanup(storage: Storage, prefix: str) -> dict:
+    """Delete every probe artifact matching `prefix` and verify zero residue.
 
     Memories are removed via `storage.delete_memory` (not raw SQL) so the
     vector and tag cascades run. `mined_patterns` and `output_log` rows have
@@ -50,30 +52,32 @@ def _cleanup(storage: Storage, nonce: str) -> dict:
 
     Args:
         storage: Storage instance to clean up.
-        nonce: The probe's content nonce, used to scope pattern/memory
-            deletes via `LIKE '%' || nonce || '%'`.
+        prefix: Scopes pattern/memory deletes via `LIKE '%' || prefix || '%'`.
+            Callers pass the constant `SENTINEL_PREFIX` (not a per-run nonce)
+            so that a pre-sweep also catches leftovers from a *prior* probe
+            run, whose nonce would otherwise never match.
 
     Returns:
         Dict with keys `memories_deleted`, `patterns_deleted`,
         `outputs_deleted` giving the counts removed.
 
     Raises:
-        AssertionError: If residue remains after cleanup.
+        RuntimeError: If residue remains after cleanup.
     """
-    like_nonce = f"%{nonce}%"
+    like_prefix = f"%{prefix}%"
 
     with storage._connection() as conn:
         memory_ids = [
             row[0]
             for row in conn.execute(
-                "SELECT id FROM memories WHERE content LIKE ?", (like_nonce,)
+                "SELECT id FROM memories WHERE content LIKE ?", (like_prefix,)
             ).fetchall()
         ]
     memories_deleted = sum(1 for mid in memory_ids if storage.delete_memory(mid))
 
     with storage.transaction() as conn:
         patterns_deleted = conn.execute(
-            "DELETE FROM mined_patterns WHERE pattern LIKE ?", (like_nonce,)
+            "DELETE FROM mined_patterns WHERE pattern LIKE ?", (like_prefix,)
         ).rowcount
         outputs_deleted = conn.execute(
             "DELETE FROM output_log WHERE session_id = ?", (PROBE_SESSION_ID,)
@@ -85,13 +89,14 @@ def _cleanup(storage: Storage, nonce: str) -> dict:
                 "SELECT COUNT(*) FROM output_log WHERE session_id = ?", (PROBE_SESSION_ID,)
             ).fetchone()[0],
             conn.execute(
-                "SELECT COUNT(*) FROM mined_patterns WHERE pattern LIKE ?", (like_nonce,)
+                "SELECT COUNT(*) FROM mined_patterns WHERE pattern LIKE ?", (like_prefix,)
             ).fetchone()[0],
             conn.execute(
-                "SELECT COUNT(*) FROM memories WHERE content LIKE ?", (like_nonce,)
+                "SELECT COUNT(*) FROM memories WHERE content LIKE ?", (like_prefix,)
             ).fetchone()[0],
         )
-    assert residue == (0, 0, 0), f"probe cleanup left residue: {residue}"
+    if residue != (0, 0, 0):
+        raise RuntimeError(f"probe cleanup left residue: {residue}")
 
     return {
         "memories_deleted": memories_deleted,
@@ -105,8 +110,10 @@ def run_probe(storage: Storage) -> ProbeResult:
 
     Logs a disposable, import-shaped sentinel, mines it with the real
     pipeline, asserts it was captured as a mined pattern, then deletes every
-    artifact it created. A clean pre-sweep runs first so leftovers from a
-    prior failed probe never accumulate or get mistaken for real data.
+    artifact it created. A clean pre-sweep runs first, scoped to the constant
+    `SENTINEL_PREFIX` rather than this run's nonce, so leftovers from a
+    prior failed probe (which used a *different* nonce) never accumulate or
+    get mistaken for real data.
 
     Args:
         storage: Storage instance to probe.
@@ -121,7 +128,7 @@ def run_probe(storage: Storage) -> ProbeResult:
     nonce = uuid4().hex[:8]
 
     try:
-        _cleanup(storage, nonce)
+        _cleanup(storage, SENTINEL_PREFIX)
     except Exception as e:  # noqa: BLE001 - reported via ProbeResult, not raised
         return ProbeResult(ok=False, stage="cleanup", error=f"{type(e).__name__}: {e}")
 
@@ -132,7 +139,7 @@ def run_probe(storage: Storage) -> ProbeResult:
         # stage can never pass. This sentinel is 37 chars (8-char nonce). If
         # a user raises the threshold past the sentinel length, the probe
         # fails at the assert stage and hook-check reports it.
-        sentinel = f"import memory_probe_sentinel_{nonce}"
+        sentinel = f"import {SENTINEL_PREFIX}{nonce}"
         storage.log_output(sentinel, session_id=PROBE_SESSION_ID)
     except Exception as e:  # noqa: BLE001
         return ProbeResult(ok=False, stage="log", error=f"{type(e).__name__}: {e}")
@@ -147,12 +154,13 @@ def run_probe(storage: Storage) -> ProbeResult:
             pattern_row = conn.execute(
                 "SELECT COUNT(*) FROM mined_patterns WHERE pattern LIKE ?", (f"%{nonce}%",)
             ).fetchone()
-        assert pattern_row[0] > 0, f"no mined_patterns row for nonce {nonce!r}"
+        if not pattern_row[0] > 0:
+            raise RuntimeError(f"no mined_patterns row for nonce {nonce!r}")
     except Exception as e:  # noqa: BLE001
         return ProbeResult(ok=False, stage="assert", error=f"{type(e).__name__}: {e}")
 
     try:
-        details = _cleanup(storage, nonce)
+        details = _cleanup(storage, SENTINEL_PREFIX)
     except Exception as e:  # noqa: BLE001
         return ProbeResult(ok=False, stage="cleanup", error=f"{type(e).__name__}: {e}")
 

--- a/src/memory_mcp/storage/core.py
+++ b/src/memory_mcp/storage/core.py
@@ -31,6 +31,7 @@ from memory_mcp.storage.hot_cache import HotCacheMixin
 from memory_mcp.storage.injection_tracking import InjectionTrackingMixin
 from memory_mcp.storage.maintenance import MaintenanceMixin
 from memory_mcp.storage.memory_crud import MemoryCrudMixin, ValidationError
+from memory_mcp.storage.mining_runs import MiningRunsMixin
 from memory_mcp.storage.mining_store import MiningStoreMixin
 from memory_mcp.storage.output_logging import OutputLoggingMixin
 from memory_mcp.storage.predictions import PredictionsMixin
@@ -46,6 +47,7 @@ log = get_logger("storage")
 class Storage(
     AuditMixin,
     TrustMixin,
+    MiningRunsMixin,
     MiningStoreMixin,
     MaintenanceMixin,
     RetrievalMixin,
@@ -66,6 +68,7 @@ class Storage(
     Combines functionality from all mixins:
     - AuditMixin: Audit logging for destructive operations
     - TrustMixin: Trust score management and history
+    - MiningRunsMixin: Mining run recording and loop health
     - MiningStoreMixin: Mined pattern storage
     - MaintenanceMixin: Database maintenance operations
     - RetrievalMixin: RAG-inspired retrieval tracking

--- a/src/memory_mcp/storage/injection_tracking.py
+++ b/src/memory_mcp/storage/injection_tracking.py
@@ -19,6 +19,61 @@ if TYPE_CHECKING:
 
 log = get_logger("injection_tracking")
 
+# How far back to look for injections when auto-marking memories as used.
+AUTO_MARK_WINDOW_HOURS = 24
+
+# Maximum number of distinctive tokens to extract per memory. Keeps the
+# match loop bounded for very long memory contents.
+TOKEN_CAP = 10
+
+# Characters that are always allowed inside a token without disqualifying
+# it from being pure-lowercase-alphabetic (identifier/path/version shapes).
+_DISTINCTIVE_MARKS = set("_./:-")
+
+# Punctuation commonly wrapped around a token (backticks, quotes, sentence
+# punctuation) that should not be considered part of the token itself.
+_STRIP_CHARS = "`'\"()[]{}<>,.;:!?"
+
+
+def distinctive_tokens(text: str, cap: int = TOKEN_CAP) -> list[str]:
+    """Extract distinctive (identifier/path/version-shaped) tokens from text.
+
+    Heuristic v1 (deliberately conservative): a distinctive token is a
+    whitespace-delimited token of length >= 6 that contains at least one of
+    ``_ . / : -``, a digit, or an internal capital (a capital letter after
+    the first character). Pure-lowercase alphabetic words are never
+    distinctive — this kills common false positives like "response",
+    "function", or "command".
+
+    Surrounding punctuation (backticks, quotes, brackets, trailing sentence
+    punctuation) is stripped before the shape check so that markdown-quoted
+    tokens like `` `deploy-staging` `` still match plain-text occurrences of
+    ``deploy-staging``.
+
+    Args:
+        text: Text to extract distinctive tokens from.
+        cap: Maximum number of tokens to return.
+
+    Returns:
+        Up to `cap` distinctive tokens, in order of first appearance,
+        duplicates removed.
+    """
+    seen: dict[str, None] = {}
+    for raw in text.split():
+        token = raw.strip(_STRIP_CHARS)
+        if len(token) < 6:
+            continue
+        if token in seen:
+            continue
+        has_mark = any(c in _DISTINCTIVE_MARKS for c in token)
+        has_digit = any(c.isdigit() for c in token)
+        has_internal_capital = any(c.isupper() for c in token[1:])
+        if has_mark or has_digit or has_internal_capital:
+            seen[token] = None
+            if len(seen) >= cap:
+                break
+    return list(seen)
+
 
 @dataclass
 class InjectionRecord:
@@ -456,3 +511,62 @@ class InjectionTrackingMixin:
             )
 
         return actions
+
+    def mark_used_memories(
+        self, response_text: str, window_hours: int = AUTO_MARK_WINDOW_HOURS
+    ) -> int:
+        """Auto-mark recently injected memories as used based on a response.
+
+        Finds memories injected within the trailing window, and for each one
+        extracts distinctive tokens (see `distinctive_tokens`) from its
+        content. A memory is considered "used" if at least one of its
+        distinctive tokens appears (case-insensitively) in `response_text`.
+        Matched memories get `used_count` incremented and `last_used_at` set
+        to now — at most once per call, regardless of how many of their
+        tokens matched.
+
+        This is heuristic v1: deliberately conservative, favoring precision
+        (few false positives) over recall.
+
+        Args:
+            response_text: The response text to search for distinctive
+                token matches.
+            window_hours: How many hours back to look for injections.
+
+        Returns:
+            Number of memories marked as used.
+        """
+        response_lower = response_text.lower()
+
+        with self.transaction() as conn:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT m.id, m.content
+                FROM injection_log i
+                JOIN memories m ON m.id = i.memory_id
+                WHERE i.injected_at >= datetime('now', ?)
+                """,
+                (f"-{window_hours} hours",),
+            ).fetchall()
+
+            matched_ids = []
+            for row in rows:
+                tokens = distinctive_tokens(row["content"])
+                if any(token.lower() in response_lower for token in tokens):
+                    matched_ids.append(row["id"])
+
+            if not matched_ids:
+                return 0
+
+            conn.executemany(
+                """
+                UPDATE memories
+                SET used_count = used_count + 1,
+                    last_used_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                [(mid,) for mid in matched_ids],
+            )
+
+        log.info("Auto-marked {} memories as used (window={}h)", len(matched_ids), window_hours)
+        return len(matched_ids)

--- a/src/memory_mcp/storage/maintenance.py
+++ b/src/memory_mcp/storage/maintenance.py
@@ -7,9 +7,12 @@ import os
 import sqlite3
 
 from memory_mcp.logging import get_logger
-from memory_mcp.models import AuditOperation, MemoryType, TrustReason
+from memory_mcp.models import AuditOperation, MemorySource, MemoryType, TrustReason
 
 log = get_logger("storage.maintenance")
+
+DECAY_DAYS = 30  # spec accepted default
+UTILITY_FLOOR = 0.0  # deviation 6
 
 
 class MaintenanceMixin:
@@ -392,6 +395,79 @@ class MaintenanceMixin:
 
         return penalized_ids
 
+    def decay_unused_mined_memories(self) -> dict:
+        """Demote and floor the utility of stale, unused mined memories.
+
+        Targets memories that were auto-mined (never human-approved), are not
+        pinned, have never been retrieved or used, and are older than
+        DECAY_DAYS. Memories with source 'mined_approved' are exempt because
+        approval is a human signal; pinned, young, retrieved, or used
+        memories are exempt for the same reason.
+
+        For each qualifying memory: demotes it from hot cache (if hot), then
+        floors its utility_score to UTILITY_FLOOR. Nothing is deleted.
+
+        Returns:
+            Dict with "demoted" (count actually removed from hot cache) and
+            "floored" (count of memories whose utility_score was floored).
+        """
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, is_hot FROM memories
+                WHERE source = ?
+                  AND is_pinned = 0
+                  AND COALESCE(retrieved_count, 0) = 0
+                  AND COALESCE(used_count, 0) = 0
+                  AND created_at < datetime('now', ?)
+                  AND (is_hot = 1 OR utility_score > ?)
+                """,
+                (MemorySource.MINED.value, f"-{DECAY_DAYS} days", UTILITY_FLOOR),
+            ).fetchall()
+
+        candidates = [(row["id"], row["is_hot"]) for row in rows]
+
+        demoted = 0
+        for memory_id, is_hot in candidates:
+            if is_hot:
+                if self.demote_from_hot(memory_id):
+                    demoted += 1
+
+        floored = 0
+        with self.transaction() as conn:
+            for memory_id, _ in candidates:
+                cursor = conn.execute(
+                    "UPDATE memories SET utility_score = ? WHERE id = ?",
+                    (UTILITY_FLOOR, memory_id),
+                )
+                floored += cursor.rowcount
+
+            if candidates:
+                self._record_audit(
+                    conn,
+                    AuditOperation.DEMOTE_STALE,
+                    target_type="memory",
+                    details=json.dumps(
+                        {
+                            "reason": "decay_unused_mined_memories",
+                            "decay_days": DECAY_DAYS,
+                            "demoted": demoted,
+                            "floored": floored,
+                        }
+                    ),
+                )
+
+        if candidates:
+            log.info(
+                "Decayed {} unused mined memories (demoted={}, floored={}, older than {} days)",
+                len(candidates),
+                demoted,
+                floored,
+                DECAY_DAYS,
+            )
+
+        return {"demoted": demoted, "floored": floored}
+
     def run_full_cleanup(self) -> dict:
         """Run comprehensive cleanup: stale memories, old logs, patterns, injections.
 
@@ -424,6 +500,9 @@ class MaintenanceMixin:
         # 8. Improve hot cache based on injection feedback (non-dry-run)
         injection_feedback = self.improve_hot_cache_from_injections(days=7, dry_run=False)
 
+        # 9. Decay unused mined memories (stale, never-retrieved/used mined facts)
+        decay_result = self.decay_unused_mined_memories()
+
         return {
             "hot_cache_demoted": len(demoted_ids),
             "patterns_expired": expired_patterns,
@@ -434,4 +513,6 @@ class MaintenanceMixin:
             "low_utility_penalized": len(penalized_ids),
             "injection_feedback_promoted": len(injection_feedback.get("promoted", [])),
             "injection_feedback_warnings": len(injection_feedback.get("warnings", [])),
+            "mined_memories_demoted": decay_result["demoted"],
+            "mined_memories_floored": decay_result["floored"],
         }

--- a/src/memory_mcp/storage/maintenance.py
+++ b/src/memory_mcp/storage/maintenance.py
@@ -398,11 +398,12 @@ class MaintenanceMixin:
     def decay_unused_mined_memories(self) -> dict:
         """Demote and floor the utility of stale, unused mined memories.
 
-        Targets memories that were auto-mined (never human-approved), are not
-        pinned, have never been retrieved or used, and are older than
-        DECAY_DAYS. Memories with source 'mined_approved' are exempt because
-        approval is a human signal; pinned, young, retrieved, or used
-        memories are exempt for the same reason.
+        Targets memories with source 'mined' that are not pinned, have never
+        been retrieved or used, and are older than DECAY_DAYS. Pinned, young,
+        retrieved, or used memories are exempt. Approval does not exempt a
+        pattern: every approval path stores source='mined' ('mined_approved'
+        exists only as a PromotionSource), so approved patterns that are
+        never pinned, retrieved, or used decay too.
 
         For each qualifying memory: demotes it from hot cache (if hot), then
         floors its utility_score to UTILITY_FLOOR. Nothing is deleted.

--- a/src/memory_mcp/storage/mining_runs.py
+++ b/src/memory_mcp/storage/mining_runs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from memory_mcp.logging import get_logger
 
@@ -134,13 +134,18 @@ class MiningRunsMixin:
             else:
                 break
 
+        # days_since_success stays whole-day for display (status/docs show
+        # it), but amber onset must trigger at the exact STALENESS_DAYS
+        # boundary, not at the day *after* whole-day truncation rounds down
+        # to it - e.g. a 7.4-day-old success must already read amber ("no
+        # successful run in 7 days"), which floor(7.4) > 7 == False would
+        # otherwise miss until day 8.
         days_since_success = _days_since(last_success_at)
+        stale = last_success_at is None or _seconds_since(last_success_at) > STALENESS_DAYS * 86400
 
         if len(recent_errors) >= ERROR_STREAK and all(row[0] is not None for row in recent_errors):
             state = "red"
-        elif last_success_at is None or (
-            days_since_success is not None and days_since_success > STALENESS_DAYS
-        ):
+        elif stale:
             state = "amber"
         else:
             state = "green"
@@ -159,8 +164,25 @@ class MiningRunsMixin:
         }
 
 
+def _elapsed_since(timestamp: str) -> timedelta:
+    """Compute the elapsed time since a stored UTC timestamp.
+
+    Args:
+        timestamp: A timestamp string in "%Y-%m-%d %H:%M:%S" UTC format.
+
+    Returns:
+        The `timedelta` between now and `timestamp`.
+    """
+    then = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - then
+
+
 def _days_since(timestamp: str | None) -> int | None:
     """Compute whole days elapsed since a stored UTC timestamp.
+
+    Used only for the `days_since_success` display field - state
+    thresholds must use `_seconds_since` so the amber boundary isn't
+    subject to whole-day truncation.
 
     Args:
         timestamp: A timestamp string in "%Y-%m-%d %H:%M:%S" UTC format, or None.
@@ -170,6 +192,16 @@ def _days_since(timestamp: str | None) -> int | None:
     """
     if timestamp is None:
         return None
-    then = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
-    delta = datetime.now(timezone.utc) - then
-    return delta.days
+    return _elapsed_since(timestamp).days
+
+
+def _seconds_since(timestamp: str) -> float:
+    """Compute exact seconds elapsed since a stored UTC timestamp.
+
+    Args:
+        timestamp: A timestamp string in "%Y-%m-%d %H:%M:%S" UTC format.
+
+    Returns:
+        Seconds elapsed as a float.
+    """
+    return _elapsed_since(timestamp).total_seconds()

--- a/src/memory_mcp/storage/mining_runs.py
+++ b/src/memory_mcp/storage/mining_runs.py
@@ -1,0 +1,175 @@
+"""Mining run recording and loop health mixin for Storage class."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from memory_mcp.logging import get_logger
+
+log = get_logger("storage.mining_runs")
+
+STALENESS_DAYS = 7
+ERROR_STREAK = 3
+PROBE_SESSION_ID = "memory-mcp-probe"
+
+
+class MiningRunsMixin:
+    """Mixin providing mining run recording and loop health queries for Storage."""
+
+    def record_mining_run(
+        self,
+        started_at: str,
+        finished_at: str,
+        stats: dict,
+        error: str | None = None,
+    ) -> int:
+        """Record a single mining loop run.
+
+        Args:
+            started_at: UTC timestamp the run started, in the same format as
+                `output_log.timestamp` (e.g. "2026-07-01 12:00:00").
+            finished_at: UTC timestamp the run finished, same format.
+            stats: Run statistics. Reads keys `outputs_processed`,
+                `patterns_found`, and `new_memories`; missing keys default to 0.
+            error: Error message if the run failed, else None.
+
+        Returns:
+            The id of the inserted `mining_runs` row.
+        """
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO mining_runs (
+                    started_at, finished_at, outputs_processed,
+                    patterns_found, memories_created, error
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    started_at,
+                    finished_at,
+                    stats.get("outputs_processed", 0),
+                    stats.get("patterns_found", 0),
+                    stats.get("new_memories", 0),
+                    error,
+                ),
+            )
+            run_id = cursor.lastrowid or 0
+            log.debug(
+                "Recorded mining run id={} error={}",
+                run_id,
+                error,
+            )
+            return run_id
+
+    def get_loop_health(self) -> dict:
+        """Compute learning-loop health from recorded mining runs and output logs.
+
+        State precedence:
+            1. "red" if the most recent `ERROR_STREAK` runs all have a
+               non-null `error` (requires at least `ERROR_STREAK` runs total).
+            2. "amber" if there is no successful run, or the last successful
+               run is older than `STALENESS_DAYS`.
+            3. "green" otherwise.
+
+        Returns:
+            Dict with keys `state`, `last_success_at`, `last_run_at`,
+            `consecutive_errors`, `total_runs`, `outputs_24h`, `outputs_7d`,
+            `patterns_7d`, `memories_7d`, `days_since_success`.
+        """
+        with self._connection() as conn:
+            total_runs = conn.execute("SELECT COUNT(*) FROM mining_runs").fetchone()[0]
+
+            last_run_row = conn.execute(
+                "SELECT started_at FROM mining_runs ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            last_run_at = last_run_row[0] if last_run_row else None
+
+            last_success_row = conn.execute(
+                """
+                SELECT started_at FROM mining_runs
+                WHERE error IS NULL
+                ORDER BY id DESC LIMIT 1
+                """
+            ).fetchone()
+            last_success_at = last_success_row[0] if last_success_row else None
+
+            recent_errors = conn.execute(
+                "SELECT error FROM mining_runs ORDER BY id DESC LIMIT ?",
+                (ERROR_STREAK,),
+            ).fetchall()
+
+            outputs_24h = conn.execute(
+                """
+                SELECT COUNT(*) FROM output_log
+                WHERE timestamp > datetime('now', '-24 hours')
+                  AND (session_id IS NULL OR session_id != ?)
+                """,
+                (PROBE_SESSION_ID,),
+            ).fetchone()[0]
+
+            outputs_7d = conn.execute(
+                """
+                SELECT COUNT(*) FROM output_log
+                WHERE timestamp > datetime('now', '-7 days')
+                  AND (session_id IS NULL OR session_id != ?)
+                """,
+                (PROBE_SESSION_ID,),
+            ).fetchone()[0]
+
+            window_row = conn.execute(
+                """
+                SELECT COALESCE(SUM(patterns_found), 0), COALESCE(SUM(memories_created), 0)
+                FROM mining_runs
+                WHERE error IS NULL
+                  AND started_at > datetime('now', ?)
+                """,
+                (f"-{STALENESS_DAYS} days",),
+            ).fetchone()
+            patterns_7d, memories_7d = window_row[0], window_row[1]
+
+        consecutive_errors = 0
+        for row in recent_errors:
+            if row[0] is not None:
+                consecutive_errors += 1
+            else:
+                break
+
+        days_since_success = _days_since(last_success_at)
+
+        if len(recent_errors) >= ERROR_STREAK and all(row[0] is not None for row in recent_errors):
+            state = "red"
+        elif last_success_at is None or (
+            days_since_success is not None and days_since_success > STALENESS_DAYS
+        ):
+            state = "amber"
+        else:
+            state = "green"
+
+        return {
+            "state": state,
+            "last_success_at": last_success_at,
+            "last_run_at": last_run_at,
+            "consecutive_errors": consecutive_errors,
+            "total_runs": total_runs,
+            "outputs_24h": outputs_24h,
+            "outputs_7d": outputs_7d,
+            "patterns_7d": patterns_7d,
+            "memories_7d": memories_7d,
+            "days_since_success": days_since_success,
+        }
+
+
+def _days_since(timestamp: str | None) -> int | None:
+    """Compute whole days elapsed since a stored UTC timestamp.
+
+    Args:
+        timestamp: A timestamp string in "%Y-%m-%d %H:%M:%S" UTC format, or None.
+
+    Returns:
+        Whole days elapsed, or None if timestamp is None.
+    """
+    if timestamp is None:
+        return None
+    then = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - then
+    return delta.days

--- a/src/memory_mcp/storage/output_logging.py
+++ b/src/memory_mcp/storage/output_logging.py
@@ -71,40 +71,43 @@ class OutputLoggingMixin:
             return log_id
 
     def get_recent_outputs(
-        self, hours: int = 24, project_id: str | None = None
+        self,
+        hours: int = 24,
+        project_id: str | None = None,
+        session_id: str | None = None,
     ) -> list[tuple[int, str, datetime, str | None, str | None]]:
-        """Get recent output logs, optionally filtered by project.
+        """Get recent output logs, optionally filtered by project and/or session.
 
         Args:
             hours: How many hours back to look.
             project_id: If provided, only return logs from this project.
                         If None, returns all logs (backwards compatible).
+            session_id: If provided, only return logs with this exact session_id.
+                        If None, returns logs from all sessions.
 
         Returns:
             List of tuples: (log_id, content, timestamp, project_id, session_id).
             The project_id and session_id are preserved for each log so mining
             can use the source project/session rather than the current one.
         """
+        query = """
+            SELECT id, content, timestamp, project_id, session_id FROM output_log
+            WHERE timestamp > datetime('now', ?)
+            """
+        params: list[str] = [f"-{hours} hours"]
+
+        if project_id:
+            query += " AND project_id = ?"
+            params.append(project_id)
+
+        if session_id:
+            query += " AND session_id = ?"
+            params.append(session_id)
+
+        query += " ORDER BY timestamp DESC"
+
         with self._connection() as conn:
-            if project_id:
-                rows = conn.execute(
-                    """
-                    SELECT id, content, timestamp, project_id, session_id FROM output_log
-                    WHERE timestamp > datetime('now', ?)
-                      AND project_id = ?
-                    ORDER BY timestamp DESC
-                    """,
-                    (f"-{hours} hours", project_id),
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    """
-                    SELECT id, content, timestamp, project_id, session_id FROM output_log
-                    WHERE timestamp > datetime('now', ?)
-                    ORDER BY timestamp DESC
-                    """,
-                    (f"-{hours} hours",),
-                ).fetchall()
+            rows = conn.execute(query, params).fetchall()
 
             return [
                 (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,6 +221,101 @@ class TestLogResponseCommand:
         finally:
             storage.close()
 
+    def _hook_stdin_and_popen_patch(self, tmp_path, assistant_text):
+        """Build hook stdin JSON + a Popen patch that suppresses the mining spawn.
+
+        Mirrors test_log_response_stores_session_id: writes a transcript with
+        a user/assistant turn, wraps hook JSON pointing at it, and intercepts
+        only the detached mining spawn (subprocess.run's `tail` call still
+        delegates to the real Popen).
+        """
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "How do I deploy?"}],
+                    }
+                }
+            ),
+            json.dumps(
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": assistant_text}],
+                    }
+                }
+            ),
+        ]
+        transcript.write_text("\n".join(lines))
+
+        hook_input = json.dumps(
+            {"transcript_path": str(transcript), "session_id": "sess-auto-mark-test"}
+        )
+
+        real_popen = subprocess.Popen
+
+        def popen_without_mining_spawn(args, **kwargs):
+            if args and args[0] == "memory-mcp-cli":
+                raise FileNotFoundError("mining spawn suppressed in test")
+            return real_popen(args, **kwargs)
+
+        return hook_input, popen_without_mining_spawn
+
+    def test_log_response_auto_marks_used_memories(self, temp_db, tmp_path, capsys):
+        """A response echoing a distinctive token from an injected memory
+        auto-marks that memory as used, right after log_output."""
+        from memory_mcp.config import get_settings
+        from memory_mcp.models import MemorySource, MemoryType
+        from memory_mcp.storage import Storage
+
+        storage = Storage(get_settings())
+        memory_id, _ = storage.store_memory(
+            content="use `make deploy-staging` for releases",
+            memory_type=MemoryType.PATTERN,
+            source=MemorySource.MINED,
+        )
+        storage.log_injection(memory_id, resource="hot-cache", session_id="s1")
+        storage.close()
+
+        hook_input, popen_patch = self._hook_stdin_and_popen_patch(
+            tmp_path, assistant_text="ran make deploy-staging"
+        )
+
+        with (
+            patch("subprocess.Popen", side_effect=popen_patch),
+            patch("sys.stdin.read", return_value=hook_input),
+            patch("sys.argv", ["memory-mcp-cli", "log-response"]),
+        ):
+            result = main()
+        assert result == 0
+
+        storage = Storage(get_settings())
+        try:
+            with storage._connection() as conn:
+                used = conn.execute(
+                    "SELECT used_count FROM memories WHERE id = ?", (memory_id,)
+                ).fetchone()[0]
+        finally:
+            storage.close()
+        assert used == 1
+
+    def test_auto_mark_failure_never_blocks_log_response(self, temp_db, tmp_path):
+        """mark_used_memories raising must not fail the Stop hook."""
+        hook_input, popen_patch = self._hook_stdin_and_popen_patch(
+            tmp_path, assistant_text="some unrelated assistant reply"
+        )
+
+        with (
+            patch.object(Storage, "mark_used_memories", side_effect=RuntimeError("boom")),
+            patch("subprocess.Popen", side_effect=popen_patch),
+            patch("sys.stdin.read", return_value=hook_input),
+            patch("sys.argv", ["memory-mcp-cli", "log-response"]),
+        ):
+            result = main()
+        assert result == 0
+
 
 class TestSeedCommand:
     """Tests for the seed CLI command."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -350,6 +350,41 @@ class TestHookCheckProbe:
         assert "stage=mine" in probe["message"]
 
 
+def _ts(days_ago: float = 0) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+class TestStatusLearningLoop:
+    def test_json_includes_learning_loop(self, temp_db, capsys):
+        with patch("sys.argv", ["memory-mcp-cli", "--json", "status"]):
+            result = main()
+        assert result == 0
+        payload = json.loads(capsys.readouterr().out)
+        loop = payload["learning_loop"]
+        assert loop["state"] == "amber"  # empty DB: never produced
+        assert loop["outputs_24h"] == 0
+
+    def test_counts_reflect_activity(self, temp_db, capsys):
+        from memory_mcp.config import Settings
+        from memory_mcp.mining import run_mining
+        from memory_mcp.storage import Storage
+
+        settings = Settings(db_path=temp_db)
+        storage = Storage(settings)
+        storage.log_output("import numpy", session_id="s1")
+        run_mining(storage, hours=1)
+        storage.close()
+        with patch("sys.argv", ["memory-mcp-cli", "--json", "status"]):
+            main()
+        loop = json.loads(capsys.readouterr().out)["learning_loop"]
+        assert loop["state"] == "green"
+        assert loop["outputs_24h"] == 1
+        assert loop["last_success_at"] is not None
+
+
 class TestCliIntegration:
     """Integration tests using subprocess."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -319,6 +319,37 @@ This is the third paragraph about dependencies.
         assert result == 1
 
 
+class TestHookCheckProbe:
+    """Tests for the loop_probe entry in hook-check."""
+
+    def test_probe_runs_by_default_and_passes(self, temp_db, capsys):
+        with patch("sys.argv", ["memory-mcp-cli", "--json", "hook-check"]):
+            result = main()
+        checks = {c["name"]: c for c in json.loads(capsys.readouterr().out)["checks"]}
+        assert "loop_probe" in checks
+        assert checks["loop_probe"]["ok"]
+        assert result == 0
+
+    def test_no_probe_skips(self, temp_db, capsys):
+        with patch("sys.argv", ["memory-mcp-cli", "--json", "hook-check", "--no-probe"]):
+            main()
+        names = [c["name"] for c in json.loads(capsys.readouterr().out)["checks"]]
+        assert "loop_probe" not in names
+
+    def test_probe_failure_fails_hook_check(self, temp_db, capsys):
+        with patch("memory_mcp.cli.run_probe") as mock_probe:
+            from memory_mcp.probe import ProbeResult
+
+            mock_probe.return_value = ProbeResult(ok=False, stage="mine", error="boom")
+            with patch("sys.argv", ["memory-mcp-cli", "--json", "hook-check"]):
+                result = main()
+        assert result != 0
+        out = json.loads(capsys.readouterr().out)
+        assert not out["success"]
+        probe = [c for c in out["checks"] if c["name"] == "loop_probe"][0]
+        assert "stage=mine" in probe["message"]
+
+
 class TestCliIntegration:
     """Integration tests using subprocess."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,8 @@ from unittest.mock import patch
 import pytest
 
 from memory_mcp.cli import main
+from memory_mcp.config import Settings
+from memory_mcp.storage import Storage
 
 
 @pytest.fixture
@@ -383,6 +385,63 @@ class TestStatusLearningLoop:
         assert loop["state"] == "green"
         assert loop["outputs_24h"] == 1
         assert loop["last_success_at"] is not None
+
+
+class TestBootstrapLoopWarning:
+    """Tests for the SessionStart staleness warning printed by `bootstrap`."""
+
+    def _seed_stale(self, db_path):
+        storage = Storage(Settings(db_path=db_path))
+        storage.record_mining_run(
+            started_at=_ts(days_ago=10),
+            finished_at=_ts(days_ago=10),
+            stats={"outputs_processed": 1, "patterns_found": 0, "new_memories": 0},
+        )
+        storage.close()
+
+    def test_stale_loop_warns_even_when_quiet(self, temp_db, tmp_path, capsys):
+        self._seed_stale(temp_db)
+        with patch("sys.argv", ["memory-mcp-cli", "bootstrap", "-r", str(tmp_path), "-q"]):
+            result = main()
+        assert result == 0
+        assert "memory loop hasn't produced" in capsys.readouterr().out
+
+    def test_healthy_loop_stays_silent(self, temp_db, tmp_path, capsys):
+        storage = Storage(Settings(db_path=temp_db))
+        storage.record_mining_run(
+            started_at=_ts(),
+            finished_at=_ts(),
+            stats={"outputs_processed": 1, "patterns_found": 1, "new_memories": 1},
+        )
+        storage.close()
+        with patch("sys.argv", ["memory-mcp-cli", "bootstrap", "-r", str(tmp_path), "-q"]):
+            main()
+        assert "memory loop" not in capsys.readouterr().out
+
+    def test_rate_limited_to_once_per_day(self, temp_db, tmp_path, capsys):
+        self._seed_stale(temp_db)
+        argv = ["memory-mcp-cli", "bootstrap", "-r", str(tmp_path), "-q"]
+        with patch("sys.argv", argv):
+            main()
+        capsys.readouterr()
+        with patch("sys.argv", argv):
+            main()
+        assert "memory loop" not in capsys.readouterr().out
+
+    def test_disabled_by_setting(self, temp_db, tmp_path, capsys):
+        self._seed_stale(temp_db)
+        with patch.dict("os.environ", {"MEMORY_MCP_LOOP_WARNINGS_ENABLED": "0"}):
+            with patch("sys.argv", ["memory-mcp-cli", "bootstrap", "-r", str(tmp_path), "-q"]):
+                main()
+        assert "memory loop" not in capsys.readouterr().out
+
+    def test_internal_error_degrades_to_silence(self, temp_db, tmp_path, capsys):
+        self._seed_stale(temp_db)
+        with patch.object(Storage, "get_loop_health", side_effect=RuntimeError("boom")):
+            with patch("sys.argv", ["memory-mcp-cli", "bootstrap", "-r", str(tmp_path), "-q"]):
+                result = main()
+        assert result == 0
+        assert "memory loop" not in capsys.readouterr().out
 
 
 class TestCliIntegration:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -539,6 +539,43 @@ class TestBootstrapLoopWarning:
         assert "memory loop" not in capsys.readouterr().out
 
 
+class TestBootstrapJsonLoopWarning:
+    """Tests for --json bootstrap embedding the staleness warning in the
+    JSON payload instead of echoing it as bare text before the payload,
+    which corrupted `| jq` consumption of stdout."""
+
+    def _seed_stale(self, db_path):
+        storage = Storage(Settings(db_path=db_path))
+        storage.record_mining_run(
+            started_at=_ts(days_ago=10),
+            finished_at=_ts(days_ago=10),
+            stats={"outputs_processed": 1, "patterns_found": 0, "new_memories": 0},
+        )
+        storage.close()
+
+    def test_stale_loop_warning_embedded_in_json_payload(self, temp_db, tmp_path, capsys):
+        self._seed_stale(temp_db)
+        with patch("sys.argv", ["memory-mcp-cli", "--json", "bootstrap", "-r", str(tmp_path)]):
+            result = main()
+        assert result == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)  # must parse cleanly - no bare text prefix
+        assert "memory loop hasn't produced" in payload["loop_warning"]
+
+    def test_second_json_run_within_stamp_window_has_no_warning(self, temp_db, tmp_path, capsys):
+        self._seed_stale(temp_db)
+        argv = ["memory-mcp-cli", "--json", "bootstrap", "-r", str(tmp_path)]
+        with patch("sys.argv", argv):
+            main()
+        capsys.readouterr()
+        with patch("sys.argv", argv):
+            result = main()
+        assert result == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)  # still valid JSON, just no warning this time
+        assert payload.get("loop_warning") in (None, "")
+
+
 class TestCliIntegration:
     """Integration tests using subprocess."""
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -130,3 +130,20 @@ class TestMiningLoopBanner:
             '<p class="text-xs text-gray-400">Output Logs</p>\n'
             '            <p class="text-2xl font-bold text-white">0</p>'
         ) in html
+
+
+class TestInjectionsPage:
+    # Storage opens its SQLite connection lazily, so on a fresh instance
+    # s._conn is None until the first query runs. These requests must be the
+    # first thing to touch the database.
+
+    def test_page_loads_on_cold_storage(self, client):
+        response = client.get("/injections")
+        assert response.status_code == 200
+        assert "Injection History" in response.text
+
+    def test_api_partial_loads_on_cold_storage(self, client):
+        # Hits _get_injections without _get_injection_stats running first,
+        # so it can't rely on an earlier call having opened the connection.
+        response = client.get("/api/injections")
+        assert response.status_code == 200

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,11 +1,19 @@
 """Tests for the dashboard FastAPI application."""
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from fastapi.testclient import TestClient
 
 from memory_mcp.config import Settings
 from memory_mcp.dashboard.app import app, get_projects
 from memory_mcp.storage import MemoryType, Storage
+from memory_mcp.storage.mining_runs import PROBE_SESSION_ID
+
+
+def _ts(days_ago: float = 0) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
 @pytest.fixture
@@ -87,3 +95,38 @@ def test_get_projects_returns_distinct_projects(dashboard_storage):
     labels = {p["label"]: p["id"] for p in projects}
     assert "owner/repo" in labels  # GitHub format shortened
     assert "project" in labels  # Absolute path shows last component
+
+
+class TestMiningLoopBanner:
+    def test_empty_db_shows_amber(self, client):
+        html = client.get("/mining").text
+        assert "loop-banner-amber" in html
+
+    def test_recent_success_shows_green(self, client, dashboard_storage):
+        dashboard_storage.record_mining_run(
+            started_at=_ts(),
+            finished_at=_ts(),
+            stats={"outputs_processed": 1, "patterns_found": 1, "new_memories": 1},
+        )
+        assert "loop-banner-green" in client.get("/mining").text
+
+    def test_error_streak_shows_red(self, client, dashboard_storage):
+        for _ in range(3):
+            dashboard_storage.record_mining_run(
+                started_at=_ts(), finished_at=_ts(), stats={}, error="boom"
+            )
+        assert "loop-banner-red" in client.get("/mining").text
+
+    def test_output_stat_excludes_probe_rows(self, client, dashboard_storage):
+        dashboard_storage.log_output("probe leftover", session_id=PROBE_SESSION_ID)
+        html = client.get("/mining").text
+        # The Output Logs stat card renders as:
+        #   <p class="text-xs text-gray-400">Output Logs</p>
+        #   <p class="text-2xl font-bold text-white">{{ mining_stats.output_count }}</p>
+        # Anchor on the label through to its value so this can't coincidentally
+        # match the "Mined Patterns" card, which shares the same value markup
+        # and would also render 0.
+        assert (
+            '<p class="text-xs text-gray-400">Output Logs</p>\n'
+            '            <p class="text-2xl font-bold text-white">0</p>'
+        ) in html

--- a/tests/test_loop_observability.py
+++ b/tests/test_loop_observability.py
@@ -276,6 +276,72 @@ class TestDistinctiveTokens:
         assert distinctive_tokens("the quick brown foxes jumped over everything") == []
 
 
+class TestUtilityDecay:
+    def _mined_memory(self, storage, days_old=31, **overrides):
+        memory_id, _ = storage.store_memory(
+            content=f"mined fact {days_old} {overrides}",
+            memory_type=MemoryType.PATTERN,
+            source=MemorySource.MINED,
+        )
+        sets = {"created_at": _ts(days_ago=days_old), **overrides}
+        assignments = ", ".join(f"{k} = ?" for k in sets)
+        with storage.transaction() as conn:
+            conn.execute(
+                f"UPDATE memories SET {assignments} WHERE id = ?",
+                (*sets.values(), memory_id),
+            )
+        return memory_id
+
+    def _row(self, storage, memory_id):
+        with storage._connection() as conn:
+            return conn.execute(
+                "SELECT is_hot, utility_score FROM memories WHERE id = ?", (memory_id,)
+            ).fetchone()
+
+    def test_demotes_and_floors_qualifying_memory(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            mid = self._mined_memory(storage, days_old=31, is_hot=1)
+            result = storage.decay_unused_mined_memories()
+            assert result["demoted"] == 1
+            is_hot, utility = self._row(storage, mid)
+            assert is_hot == 0 and utility == 0.0
+            assert self._row(storage, mid) is not None  # nothing deleted
+        finally:
+            storage.close()
+
+    def test_exemptions(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            pinned = self._mined_memory(storage, days_old=31, is_hot=1, is_pinned=1)
+            young = self._mined_memory(storage, days_old=29, is_hot=1)
+            retrieved = self._mined_memory(storage, days_old=31, is_hot=1, retrieved_count=2)
+            used = self._mined_memory(storage, days_old=31, is_hot=1, used_count=1)
+            storage.decay_unused_mined_memories()
+            for mid in (pinned, young, retrieved, used):
+                assert self._row(storage, mid)[0] == 1, f"memory {mid} wrongly demoted"
+        finally:
+            storage.close()
+
+    def test_non_mined_sources_exempt(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            memory_id, _ = storage.store_memory(
+                content="user seeded fact",
+                memory_type=MemoryType.PATTERN,
+                source=MemorySource.MANUAL,
+            )
+            with storage.transaction() as conn:
+                conn.execute(
+                    "UPDATE memories SET created_at = ?, is_hot = 1 WHERE id = ?",
+                    (_ts(days_ago=40), memory_id),
+                )
+            storage.decay_unused_mined_memories()
+            assert self._row(storage, memory_id)[0] == 1
+        finally:
+            storage.close()
+
+
 class TestMarkUsedMemories:
     def _inject(self, storage, content):
         memory_id, _ = storage.store_memory(

--- a/tests/test_loop_observability.py
+++ b/tests/test_loop_observability.py
@@ -7,6 +7,7 @@ import pytest
 
 from memory_mcp.migrations import SCHEMA_VERSION
 from memory_mcp.mining import run_mining
+from memory_mcp.probe import run_probe
 from memory_mcp.storage import Storage
 from memory_mcp.storage.mining_runs import PROBE_SESSION_ID
 
@@ -202,5 +203,61 @@ class TestRunMiningPersistence:
             storage.log_output("import beta_only_lib", session_id="s-beta")
             result = run_mining(storage, hours=1, session_id="s-alpha", record_run=False)
             assert result["outputs_processed"] == 1
+        finally:
+            storage.close()
+
+
+def _residue(storage) -> tuple[int, int, int]:
+    with storage._connection() as conn:
+        outputs = conn.execute(
+            "SELECT COUNT(*) FROM output_log WHERE session_id = ?", (PROBE_SESSION_ID,)
+        ).fetchone()[0]
+        patterns = conn.execute(
+            "SELECT COUNT(*) FROM mined_patterns WHERE pattern LIKE '%memory_probe_%'"
+        ).fetchone()[0]
+        memories = conn.execute(
+            "SELECT COUNT(*) FROM memories WHERE content LIKE '%memory_probe_%'"
+        ).fetchone()[0]
+    return outputs, patterns, memories
+
+
+class TestProbe:
+    def test_round_trip_succeeds_on_clean_db(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            result = run_probe(storage)
+            assert result.ok, f"failed at {result.stage}: {result.error}"
+        finally:
+            storage.close()
+
+    def test_no_residue_after_success(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            run_probe(storage)
+            assert _residue(storage) == (0, 0, 0)
+            assert _count_runs(storage) == 0  # deviation 1: never records a run
+        finally:
+            storage.close()
+
+    def test_failure_reports_stage(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            with patch("memory_mcp.probe.run_mining", side_effect=RuntimeError("wiring")):
+                result = run_probe(storage)
+            assert not result.ok
+            assert result.stage == "mine"
+            assert "wiring" in result.error
+        finally:
+            storage.close()
+
+    def test_leftovers_excluded_from_health_and_swept_by_next_probe(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            with patch("memory_mcp.probe.run_mining", side_effect=RuntimeError("wiring")):
+                run_probe(storage)  # leaves the sentinel output behind
+            assert storage.get_loop_health()["outputs_24h"] == 0  # marker excluded
+            result = run_probe(storage)  # pre-sweep + fresh round trip
+            assert result.ok
+            assert _residue(storage) == (0, 0, 0)
         finally:
             storage.close()

--- a/tests/test_loop_observability.py
+++ b/tests/test_loop_observability.py
@@ -1,0 +1,46 @@
+"""Tests for v0.8 loop observability: mining_runs, probe, health, decay."""
+
+from memory_mcp.migrations import SCHEMA_VERSION
+from memory_mcp.storage import Storage
+
+
+class TestMiningRunsMigration:
+    def _columns(self, storage, table):
+        with storage._connection() as conn:
+            rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        return {row[1] for row in rows}
+
+    # Mirror the Storage import used by tests/test_storage.py if the package
+    # __init__ does not re-export it.
+
+    def test_fresh_db_has_mining_runs_table(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            cols = self._columns(storage, "mining_runs")
+            assert cols == {
+                "id",
+                "started_at",
+                "finished_at",
+                "outputs_processed",
+                "patterns_found",
+                "memories_created",
+                "error",
+            }
+            assert storage.get_schema_version() == SCHEMA_VERSION
+        finally:
+            storage.close()
+
+    def test_v17_db_gains_table_on_reopen(self, temp_settings):
+        storage = Storage(temp_settings)
+        with storage.transaction() as conn:
+            conn.execute("DROP TABLE mining_runs")
+            conn.execute("DELETE FROM schema_version")
+            conn.execute("INSERT INTO schema_version (version) VALUES (17)")
+        storage.close()
+
+        storage = Storage(temp_settings)
+        try:
+            assert "started_at" in self._columns(storage, "mining_runs")
+            assert storage.get_schema_version() == SCHEMA_VERSION
+        finally:
+            storage.close()

--- a/tests/test_loop_observability.py
+++ b/tests/test_loop_observability.py
@@ -127,6 +127,28 @@ class TestLoopHealth:
         finally:
             storage.close()
 
+    def test_success_past_7_days_boundary_is_amber(self, temp_settings):
+        """A success 7.4 days old must be amber per the documented boundary
+        ("no successful run in 7 days"). Whole-day truncation of
+        days_since_success previously reported this as green, since
+        floor(7.4) == 7 is not > STALENESS_DAYS (7)."""
+        storage = Storage(temp_settings)
+        try:
+            self._seed_run(storage, days_ago=7.4)
+            health = storage.get_loop_health()
+            assert health["state"] == "amber"
+        finally:
+            storage.close()
+
+    def test_success_under_7_days_boundary_is_green(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            self._seed_run(storage, days_ago=6.9)
+            health = storage.get_loop_health()
+            assert health["state"] == "green"
+        finally:
+            storage.close()
+
     def test_error_streak_is_red(self, temp_settings):
         storage = Storage(temp_settings)
         try:
@@ -260,6 +282,35 @@ class TestProbe:
             assert storage.get_loop_health()["outputs_24h"] == 0  # marker excluded
             result = run_probe(storage)  # pre-sweep + fresh round trip
             assert result.ok
+            assert _residue(storage) == (0, 0, 0)
+        finally:
+            storage.close()
+
+    def test_pre_sweep_removes_prior_probe_leftovers(self, temp_settings):
+        """A prior probe's nonce differs from the current run's nonce, so a
+        pre-sweep scoped to that stale nonce (instead of the constant
+        sentinel prefix) leaves the leftover behind forever."""
+        storage = Storage(temp_settings)
+        try:
+            with storage.transaction() as conn:
+                conn.execute(
+                    "INSERT INTO mined_patterns (pattern, pattern_hash, pattern_type)"
+                    " VALUES (?, ?, ?)",
+                    (
+                        "import memory_probe_sentinel_deadbeef",
+                        "leftover-pattern-hash",
+                        "import",
+                    ),
+                )
+            storage.store_memory(
+                content="import memory_probe_sentinel_deadbeef",
+                memory_type=MemoryType.PATTERN,
+                source=MemorySource.MINED,
+            )
+
+            result = run_probe(storage)
+
+            assert result.ok, f"failed at {result.stage}: {result.error}"
             assert _residue(storage) == (0, 0, 0)
         finally:
             storage.close()

--- a/tests/test_loop_observability.py
+++ b/tests/test_loop_observability.py
@@ -1,8 +1,12 @@
 """Tests for v0.8 loop observability: mining_runs, probe, health, decay."""
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
 
 from memory_mcp.migrations import SCHEMA_VERSION
+from memory_mcp.mining import run_mining
 from memory_mcp.storage import Storage
 from memory_mcp.storage.mining_runs import PROBE_SESSION_ID
 
@@ -140,5 +144,63 @@ class TestLoopHealth:
             health = storage.get_loop_health()
             assert health["outputs_24h"] == 1
             assert health["outputs_7d"] == 1
+        finally:
+            storage.close()
+
+
+def _count_runs(storage) -> int:
+    with storage._connection() as conn:
+        return conn.execute("SELECT COUNT(*) FROM mining_runs").fetchone()[0]
+
+
+class TestRunMiningPersistence:
+    def test_successful_run_is_recorded(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            storage.log_output("import numpy as np", session_id="s1")
+            result = run_mining(storage, hours=1)
+            with storage._connection() as conn:
+                row = conn.execute(
+                    "SELECT outputs_processed, patterns_found, memories_created, error"
+                    " FROM mining_runs"
+                ).fetchone()
+            assert row[0] == result["outputs_processed"]
+            assert row[1] == result["patterns_found"]
+            assert row[2] == result["new_memories"]
+            assert row[3] is None
+        finally:
+            storage.close()
+
+    def test_failed_run_records_error_and_reraises(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            storage.log_output("import numpy as np", session_id="s1")
+            with patch(
+                "memory_mcp.mining.extract_patterns",
+                side_effect=RuntimeError("extractor exploded"),
+            ):
+                with pytest.raises(RuntimeError):
+                    run_mining(storage, hours=1)
+            with storage._connection() as conn:
+                row = conn.execute("SELECT error FROM mining_runs").fetchone()
+            assert "extractor exploded" in row[0]
+        finally:
+            storage.close()
+
+    def test_record_run_false_writes_nothing(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            run_mining(storage, hours=1, record_run=False)
+            assert _count_runs(storage) == 0
+        finally:
+            storage.close()
+
+    def test_session_id_scopes_outputs(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            storage.log_output("import alpha_only_lib", session_id="s-alpha")
+            storage.log_output("import beta_only_lib", session_id="s-beta")
+            result = run_mining(storage, hours=1, session_id="s-alpha", record_run=False)
+            assert result["outputs_processed"] == 1
         finally:
             storage.close()

--- a/tests/test_loop_observability.py
+++ b/tests/test_loop_observability.py
@@ -1,7 +1,10 @@
 """Tests for v0.8 loop observability: mining_runs, probe, health, decay."""
 
+from datetime import datetime, timedelta, timezone
+
 from memory_mcp.migrations import SCHEMA_VERSION
 from memory_mcp.storage import Storage
+from memory_mcp.storage.mining_runs import PROBE_SESSION_ID
 
 
 class TestMiningRunsMigration:
@@ -42,5 +45,100 @@ class TestMiningRunsMigration:
         try:
             assert "started_at" in self._columns(storage, "mining_runs")
             assert storage.get_schema_version() == SCHEMA_VERSION
+        finally:
+            storage.close()
+
+
+def _ts(days_ago: float = 0) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+class TestMiningRunRecording:
+    def test_records_successful_run(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            run_id = storage.record_mining_run(
+                started_at=_ts(),
+                finished_at=_ts(),
+                stats={"outputs_processed": 4, "patterns_found": 2, "new_memories": 1},
+            )
+            with storage._connection() as conn:
+                row = conn.execute(
+                    "SELECT outputs_processed, patterns_found, memories_created, error"
+                    " FROM mining_runs WHERE id = ?",
+                    (run_id,),
+                ).fetchone()
+            assert tuple(row) == (4, 2, 1, None)
+        finally:
+            storage.close()
+
+    def test_records_failed_run(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            storage.record_mining_run(started_at=_ts(), finished_at=_ts(), stats={}, error="boom")
+            with storage._connection() as conn:
+                row = conn.execute("SELECT error FROM mining_runs").fetchone()
+            assert row[0] == "boom"
+        finally:
+            storage.close()
+
+
+class TestLoopHealth:
+    def _seed_run(self, storage, days_ago, error=None):
+        storage.record_mining_run(
+            started_at=_ts(days_ago),
+            finished_at=_ts(days_ago),
+            stats={"outputs_processed": 1, "patterns_found": 1, "new_memories": 1},
+            error=error,
+        )
+
+    def test_empty_db_is_amber(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            health = storage.get_loop_health()
+            assert health["state"] == "amber"
+            assert health["last_success_at"] is None
+        finally:
+            storage.close()
+
+    def test_recent_success_is_green(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            self._seed_run(storage, days_ago=1)
+            assert storage.get_loop_health()["state"] == "green"
+        finally:
+            storage.close()
+
+    def test_stale_success_is_amber(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            self._seed_run(storage, days_ago=8)
+            health = storage.get_loop_health()
+            assert health["state"] == "amber"
+            assert health["days_since_success"] >= 8
+        finally:
+            storage.close()
+
+    def test_error_streak_is_red(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            self._seed_run(storage, days_ago=2)  # old success
+            for _ in range(3):
+                self._seed_run(storage, days_ago=0, error="boom")
+            health = storage.get_loop_health()
+            assert health["state"] == "red"
+            assert health["consecutive_errors"] == 3
+        finally:
+            storage.close()
+
+    def test_probe_outputs_excluded_from_counts(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            storage.log_output("real output content", session_id="real-session")
+            storage.log_output("probe sentinel content", session_id=PROBE_SESSION_ID)
+            health = storage.get_loop_health()
+            assert health["outputs_24h"] == 1
+            assert health["outputs_7d"] == 1
         finally:
             storage.close()

--- a/tests/test_loop_observability.py
+++ b/tests/test_loop_observability.py
@@ -7,8 +7,10 @@ import pytest
 
 from memory_mcp.migrations import SCHEMA_VERSION
 from memory_mcp.mining import run_mining
+from memory_mcp.models import MemorySource, MemoryType
 from memory_mcp.probe import run_probe
 from memory_mcp.storage import Storage
+from memory_mcp.storage.injection_tracking import distinctive_tokens
 from memory_mcp.storage.mining_runs import PROBE_SESSION_ID
 
 
@@ -259,5 +261,60 @@ class TestProbe:
             result = run_probe(storage)  # pre-sweep + fresh round trip
             assert result.ok
             assert _residue(storage) == (0, 0, 0)
+        finally:
+            storage.close()
+
+
+class TestDistinctiveTokens:
+    def test_identifier_shapes_are_distinctive(self):
+        tokens = distinctive_tokens("run deploy-staging via make_target or FooBarBaz v1.2.3")
+        assert "deploy-staging" in tokens
+        assert "make_target" in tokens
+        assert "FooBarBaz" in tokens
+
+    def test_common_words_are_not(self):
+        assert distinctive_tokens("the quick brown foxes jumped over everything") == []
+
+
+class TestMarkUsedMemories:
+    def _inject(self, storage, content):
+        memory_id, _ = storage.store_memory(
+            content=content, memory_type=MemoryType.PATTERN, source=MemorySource.MINED
+        )
+        storage.log_injection(memory_id, resource="hot-cache", session_id="s1")
+        return memory_id
+
+    def _used(self, storage, memory_id):
+        with storage._connection() as conn:
+            return conn.execute(
+                "SELECT used_count, last_used_at FROM memories WHERE id = ?", (memory_id,)
+            ).fetchone()
+
+    def test_true_positive_bumps_used_count(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            mid = self._inject(storage, "use `make deploy-staging` for releases")
+            n = storage.mark_used_memories("I ran make deploy-staging and it worked")
+            assert n == 1
+            used_count, last_used_at = self._used(storage, mid)
+            assert used_count == 1 and last_used_at is not None
+        finally:
+            storage.close()
+
+    def test_near_miss_common_words_do_not_match(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            mid = self._inject(storage, "always check the command output first")
+            assert storage.mark_used_memories("the command failed with an error") == 0
+            assert self._used(storage, mid)[0] == 0
+        finally:
+            storage.close()
+
+    def test_injected_but_unused_untouched(self, temp_settings):
+        storage = Storage(temp_settings)
+        try:
+            mid = self._inject(storage, "use `make deploy-staging` for releases")
+            assert storage.mark_used_memories("unrelated response text entirely") == 0
+            assert self._used(storage, mid)[0] == 0
         finally:
             storage.close()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,25 @@
+"""Structural validation for the Claude Code plugin."""
+
+import json
+import re
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).parent.parent / ".claude-plugin"
+
+
+def test_plugin_json_is_valid():
+    manifest = json.loads((PLUGIN_DIR / "plugin.json").read_text())
+    assert manifest["name"]
+
+
+def test_recall_nudge_skill_structure():
+    skill = PLUGIN_DIR / "skills" / "recall-nudge" / "SKILL.md"
+    assert skill.exists()
+    text = skill.read_text()
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match, "missing YAML frontmatter"
+    frontmatter = match.group(1)
+    assert "name: recall-nudge" in frontmatter
+    assert "description:" in frontmatter
+    for phrase in ("didn't we", "last time", "how did we"):
+        assert phrase in text.lower()


### PR DESCRIPTION
## Summary

The Stop-hook learning loop silently failed for five months because nothing watched the loop itself — `hook-check` verified prerequisites while the mining step died on every invocation. v0.8.0 makes that failure class impossible to miss, and makes mined memories earn their place:

- **`mining_runs` table (migration v18)** — every real mining run records its outcome; the DB, not logs, is the source of truth for loop health
- **Round-trip probe in `hook-check`** (`--no-probe` to skip) — log → mine → assert → cleanup against the real pipeline; catches wiring bugs of the `--session-id` class on day one
- **One health model, three surfaces** — `status` Learning Loop section, dashboard mining-page banner, and a once-per-day SessionStart warning all read the same `get_loop_health()` (green / amber at 7 days without success / red at 3 consecutive errors)
- **Utility feedback** — `log-response` marks injected memories used via conservative distinctive-token matching; maintenance decays mined memories with zero retrievals and zero uses after 30 days (demote + floor, nothing deleted; pinned exempt)
- **recall-nudge plugin skill** — nudges a `recall` call on retrospective questions, feeding the usage signal
- Docs: CHANGELOG under `[Unreleased]`, REFERENCE.md (fact-checked claim-by-claim against source), README dashboard line
- Also included: injections-page cold-storage 500 fix (82b71c5) and final-review fixes (probe leftover sweep by sentinel prefix, `--json bootstrap` gains a `loop_warning` key instead of corrupting the payload, `assert`→`RuntimeError` hardening, exact-seconds staleness boundary)

Plan with global constraints and 8 documented deviations: `.planning/superpowers/plans/2026-07-01-v0.8-loop-observability-plan.md`; spec: `docs/superpowers/specs/2026-07-01-v0.8-loop-observability-design.md`.

## Open items for the owner

1. **Approval does not exempt from decay**: approving a mined pattern never changes `memories.source`, so approved-but-never-used patterns can still decay after 30 days. Docs state this real behavior. If approval should protect, that's a small post-merge code change.
2. One plan-mandated test (`test_auto_mark_failure_never_blocks_log_response`) passes trivially pre-implementation by design; it guards a real call site post-implementation.

Release cut (version bump, `uv lock`, tag) is deliberately not in this PR — run `./scripts/bump-version.sh 0.8.0` + `/release` after merge.

## Test plan

- [x] Full suite at HEAD: 721 passed, 2 skipped, 0 failures (run twice independently)
- [x] `ruff check` and `ruff format --check` clean
- [x] Runtime sweep on scratch DBs: probe green via `hook-check` (exit 0); seeded run turns `status` learning_loop green; dashboard `/mining` serves `loop-banner-green`; stale DB triggers exactly one bootstrap warning, second run silent
- [x] Broken-DB negative test: read-only DB makes the probe fail with a named stage and exit 1
- [x] Every task TDD'd (failing test first, evidence in commit history); per-task spec+quality reviews; whole-branch final review with empirically-verified findings, all fixed and re-verified