### PR TITLE
fix: graph page Connected Memories stat always showed 0

### DIFF
--- a/src/memory_mcp/dashboard/templates/graph.html
+++ b/src/memory_mcp/dashboard/templates/graph.html
@@ -18,7 +18,7 @@
         </div>
         <div class="bg-dark-900 rounded-lg border border-gray-800 p-4">
             <p class="text-xs text-gray-400">Connected Memories</p>
-            <p class="text-2xl font-bold text-white">{{ stats.get('connected_memories', 0) }}</p>
+            <p class="text-2xl font-bold text-white">{{ stats.get('linked_memories', 0) }}</p>
         </div>
         {% for rel_type, count in stats.get('by_type', {}).items() %}
         <div class="bg-dark-900 rounded-lg border border-gray-800 p-4">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,5 +1,6 @@
 """Tests for the dashboard FastAPI application."""
 
+import re
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -147,3 +148,22 @@ class TestInjectionsPage:
         # so it can't rely on an earlier call having opened the connection.
         response = client.get("/api/injections")
         assert response.status_code == 200
+
+
+class TestKnowledgeGraph:
+    """Graph page stats reflect real relationship counts."""
+
+    def test_graph_page_stats_show_linked_memory_count(self, client, dashboard_storage):
+        # get_relationship_stats() reports the count under 'linked_memories';
+        # the card must read that key, not the fallback 0.
+        from memory_mcp.models import RelationType
+
+        a, _ = dashboard_storage.store_memory("stats node a", MemoryType.PROJECT)
+        b, _ = dashboard_storage.store_memory("stats node b", MemoryType.REFERENCE)
+        dashboard_storage.link_memories(a, b, RelationType.DEPENDS_ON)
+
+        resp = client.get("/graph")
+        assert resp.status_code == 200
+        card = re.search(r"Connected Memories</p>\s*<p[^>]*>(\d+)</p>", resp.text)
+        assert card is not None
+        assert card.group(1) == "2"


### PR DESCRIPTION
## What

The Knowledge Graph page's **Connected Memories** stat card always rendered `0`, regardless of how many memories were linked.

## Root cause

`graph.html` read the stat under `stats.get('connected_memories', 0)`, but `get_relationship_stats()` in `storage/relationships.py` returns the count under the key `linked_memories`. The key never matched, so the template silently fell back to `0`.

## Fix

- Point the template at the correct key (`linked_memories`) — the visible card label is unchanged.
- Add `TestKnowledgeGraph.test_graph_page_stats_show_linked_memory_count`: seeds two memories, links them, and asserts the card renders the real count (`2`) rather than the `0` fallback.

## Verification

- New test fails before the fix (`assert '0' == '2'`) and passes after.
- Full `tests/test_dashboard.py` passes (11 tests); `ruff check` clean; pre-commit hooks pass.

The same one-line key mismatch also exists in the interactive `graph.html` on the `dashboard-gui-improvements` feature branch; it's fixed there separately so neither branch regresses when they reconcile.